### PR TITLE
chore(release): v0.9.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.9.16 — 2026-05-07
+
 ### Correctness x-ray fix programme
 
 A focused audit by five specialised investigators (concurrency, auth,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1226,7 +1226,7 @@ dependencies = [
 
 [[package]]
 name = "deltaglider_proxy"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "aes-gcm",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltaglider_proxy"
-version = "0.9.15"
+version = "0.9.16"
 description = "S3-compatible proxy with transparent delta compression"
 license = "GPL-2.0-only"
 readme = "README.md"


### PR DESCRIPTION
Automated release prep (manual completion after `gh: command not found` regression in prepare-release.yml).

## What this PR does

- Bumps `Cargo.toml` and `Cargo.lock` to v0.9.16
- Rolls `## Unreleased` in `CHANGELOG.md` into `## v0.9.16 — 2026-05-07`

## Reviewer checklist

- [ ] CHANGELOG section under `## v0.9.16` reads correctly
- [ ] CI green on this PR

## What happens on merge

`tag-on-merge.yml` reads the version from the PR title, tags the merge commit `v0.9.16`, and pushes it. That fires `release.yml` (CI gate → 4-target builds → multi-arch Docker → GitHub Release with SBOM and attestation).