### PR TITLE
ci(builder): add clang + lld so .cargo/config.toml works in CI

### DIFF
--- a/.github/builder/Dockerfile
+++ b/.github/builder/Dockerfile
@@ -6,13 +6,17 @@ LABEL org.opencontainers.image.description="CI builder for DeltaGlider Proxy —
 ENV DEBIAN_FRONTEND=noninteractive
 
 # ── System packages ─────────────────────────────────────────────────
+# clang + lld are required by .cargo/config.toml which pins
+# `linker = "clang"` with `-fuse-ld=lld` for ~3-5× faster linking.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     ca-certificates \
+    clang \
     curl \
     git \
     jq \
     libssl-dev \
+    lld \
     pkg-config \
     wget \
     xdelta3 \
@@ -63,4 +67,6 @@ RUN echo "--- Builder image verification ---" \
   && mc --version \
   && docker --version \
   && git --version \
+  && clang --version \
+  && ld.lld --version \
   && echo "--- All tools OK ---"


### PR DESCRIPTION
## Summary

Every CI job has been failing since `2026-05-17T17:42Z` with:

```
error: linker `clang` not found
error: could not compile `proc-macro2` (build script)
...
##[error]Process completed with exit code 101.
```

The recent compile-time optimization PR (merge `9d80c57`) added a repo-level `.cargo/config.toml`:

```toml
[target.x86_64-unknown-linux-gnu]
linker = "clang"
rustflags = ["-C", "link-arg=-fuse-ld=lld"]
```

…but the CI `builder` image only ships `build-essential` (gcc/g++). No `clang`, no `lld`. Every `cargo build` inside the container dies at the link step, cascading every build-gated job (clippy, unit tests, delta tests, s3s adapter, e2e smoke, docs link check, config json schema).

Last green CI was [25997746607](https://github.com/beshu-tech/deltaglider_proxy/actions/runs/25997746607) at 17:28Z, immediately before that PR landed.

## Changes

Two-line `apt-get install` addition (`clang`, `lld`) plus verification steps (`clang --version`, `ld.lld --version`) so the next builder rebuild proves the install.

## Test plan

- [x] Manually installed clang+lld on the LXC host runners (`gh-beshu-*`) — confirmed root cause was the *container image*, not the LXC host, since jobs still failed after host-level install (DGP jobs all use `container: ghcr.io/.../builder:latest`).
- [ ] Merge this → `builder-image.yml` auto-fires on `paths: [.github/builder/**]`.
- [ ] CI re-runs on `main` should go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)