### PR TITLE
Event-driven replication over the durable outbox

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -639,6 +639,7 @@ jobs:
           npm run test:rule-names
           npm run test:lifecycle-helpers
           npm run test:upload-telemetry
+          npm run test:webhook-delivery-payload
       - name: npm audit
         run: cd demo/s3-browser/ui && npm audit --audit-level=high || true  # warn-only
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,15 @@ jobs:
     runs-on: k3s
     container:
       image: ghcr.io/beshu-tech/deltaglider_proxy/builder:latest
+      # Raise the open-file limit. These jobs run on the self-hosted
+      # `k3s`-labelled Ryzen LXC runners, where the container inherits a low
+      # default nofile (~1024). The integration suite spawns ~35 test
+      # binaries in parallel, each with its own proxy + MinIO sockets, so the
+      # aggregate fd count blows past 1024 and surfaces as
+      # `ConnectError("tcp open error", Os code 24 "Too many open files")`.
+      # The LXC host also bumps nofile (lxc.prlimit.nofile) — this is the
+      # belt-and-suspenders so the workflow is self-documenting and portable.
+      options: --ulimit nofile=1048576:1048576
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -94,6 +103,15 @@ jobs:
     runs-on: k3s
     container:
       image: ghcr.io/beshu-tech/deltaglider_proxy/builder:latest
+      # Raise the open-file limit. These jobs run on the self-hosted
+      # `k3s`-labelled Ryzen LXC runners, where the container inherits a low
+      # default nofile (~1024). The integration suite spawns ~35 test
+      # binaries in parallel, each with its own proxy + MinIO sockets, so the
+      # aggregate fd count blows past 1024 and surfaces as
+      # `ConnectError("tcp open error", Os code 24 "Too many open files")`.
+      # The LXC host also bumps nofile (lxc.prlimit.nofile) — this is the
+      # belt-and-suspenders so the workflow is self-documenting and portable.
+      options: --ulimit nofile=1048576:1048576
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -158,6 +176,15 @@ jobs:
     timeout-minutes: 15
     container:
       image: ghcr.io/beshu-tech/deltaglider_proxy/builder:latest
+      # Raise the open-file limit. These jobs run on the self-hosted
+      # `k3s`-labelled Ryzen LXC runners, where the container inherits a low
+      # default nofile (~1024). The integration suite spawns ~35 test
+      # binaries in parallel, each with its own proxy + MinIO sockets, so the
+      # aggregate fd count blows past 1024 and surfaces as
+      # `ConnectError("tcp open error", Os code 24 "Too many open files")`.
+      # The LXC host also bumps nofile (lxc.prlimit.nofile) — this is the
+      # belt-and-suspenders so the workflow is self-documenting and portable.
+      options: --ulimit nofile=1048576:1048576
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -186,6 +213,15 @@ jobs:
     continue-on-error: true
     container:
       image: ghcr.io/beshu-tech/deltaglider_proxy/builder:latest
+      # Raise the open-file limit. These jobs run on the self-hosted
+      # `k3s`-labelled Ryzen LXC runners, where the container inherits a low
+      # default nofile (~1024). The integration suite spawns ~35 test
+      # binaries in parallel, each with its own proxy + MinIO sockets, so the
+      # aggregate fd count blows past 1024 and surfaces as
+      # `ConnectError("tcp open error", Os code 24 "Too many open files")`.
+      # The LXC host also bumps nofile (lxc.prlimit.nofile) — this is the
+      # belt-and-suspenders so the workflow is self-documenting and portable.
+      options: --ulimit nofile=1048576:1048576
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -256,6 +292,15 @@ jobs:
     timeout-minutes: 50
     container:
       image: ghcr.io/beshu-tech/deltaglider_proxy/builder:latest
+      # Raise the open-file limit. These jobs run on the self-hosted
+      # `k3s`-labelled Ryzen LXC runners, where the container inherits a low
+      # default nofile (~1024). The integration suite spawns ~35 test
+      # binaries in parallel, each with its own proxy + MinIO sockets, so the
+      # aggregate fd count blows past 1024 and surfaces as
+      # `ConnectError("tcp open error", Os code 24 "Too many open files")`.
+      # The LXC host also bumps nofile (lxc.prlimit.nofile) — this is the
+      # belt-and-suspenders so the workflow is self-documenting and portable.
+      options: --ulimit nofile=1048576:1048576
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -394,6 +439,15 @@ jobs:
     timeout-minutes: 15
     container:
       image: ghcr.io/beshu-tech/deltaglider_proxy/builder:latest
+      # Raise the open-file limit. These jobs run on the self-hosted
+      # `k3s`-labelled Ryzen LXC runners, where the container inherits a low
+      # default nofile (~1024). The integration suite spawns ~35 test
+      # binaries in parallel, each with its own proxy + MinIO sockets, so the
+      # aggregate fd count blows past 1024 and surfaces as
+      # `ConnectError("tcp open error", Os code 24 "Too many open files")`.
+      # The LXC host also bumps nofile (lxc.prlimit.nofile) — this is the
+      # belt-and-suspenders so the workflow is self-documenting and portable.
+      options: --ulimit nofile=1048576:1048576
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -421,6 +475,15 @@ jobs:
     timeout-minutes: 35
     container:
       image: ghcr.io/beshu-tech/deltaglider_proxy/builder:latest
+      # Raise the open-file limit. These jobs run on the self-hosted
+      # `k3s`-labelled Ryzen LXC runners, where the container inherits a low
+      # default nofile (~1024). The integration suite spawns ~35 test
+      # binaries in parallel, each with its own proxy + MinIO sockets, so the
+      # aggregate fd count blows past 1024 and surfaces as
+      # `ConnectError("tcp open error", Os code 24 "Too many open files")`.
+      # The LXC host also bumps nofile (lxc.prlimit.nofile) — this is the
+      # belt-and-suspenders so the workflow is self-documenting and portable.
+      options: --ulimit nofile=1048576:1048576
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -450,6 +513,15 @@ jobs:
     runs-on: k3s
     container:
       image: ghcr.io/beshu-tech/deltaglider_proxy/builder:latest
+      # Raise the open-file limit. These jobs run on the self-hosted
+      # `k3s`-labelled Ryzen LXC runners, where the container inherits a low
+      # default nofile (~1024). The integration suite spawns ~35 test
+      # binaries in parallel, each with its own proxy + MinIO sockets, so the
+      # aggregate fd count blows past 1024 and surfaces as
+      # `ConnectError("tcp open error", Os code 24 "Too many open files")`.
+      # The LXC host also bumps nofile (lxc.prlimit.nofile) — this is the
+      # belt-and-suspenders so the workflow is self-documenting and portable.
+      options: --ulimit nofile=1048576:1048576
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -470,6 +542,15 @@ jobs:
     runs-on: k3s
     container:
       image: ghcr.io/beshu-tech/deltaglider_proxy/builder:latest
+      # Raise the open-file limit. These jobs run on the self-hosted
+      # `k3s`-labelled Ryzen LXC runners, where the container inherits a low
+      # default nofile (~1024). The integration suite spawns ~35 test
+      # binaries in parallel, each with its own proxy + MinIO sockets, so the
+      # aggregate fd count blows past 1024 and surfaces as
+      # `ConnectError("tcp open error", Os code 24 "Too many open files")`.
+      # The LXC host also bumps nofile (lxc.prlimit.nofile) — this is the
+      # belt-and-suspenders so the workflow is self-documenting and portable.
+      options: --ulimit nofile=1048576:1048576
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -494,6 +575,15 @@ jobs:
     runs-on: k3s
     container:
       image: ghcr.io/beshu-tech/deltaglider_proxy/builder:latest
+      # Raise the open-file limit. These jobs run on the self-hosted
+      # `k3s`-labelled Ryzen LXC runners, where the container inherits a low
+      # default nofile (~1024). The integration suite spawns ~35 test
+      # binaries in parallel, each with its own proxy + MinIO sockets, so the
+      # aggregate fd count blows past 1024 and surfaces as
+      # `ConnectError("tcp open error", Os code 24 "Too many open files")`.
+      # The LXC host also bumps nofile (lxc.prlimit.nofile) — this is the
+      # belt-and-suspenders so the workflow is self-documenting and portable.
+      options: --ulimit nofile=1048576:1048576
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -565,6 +655,15 @@ jobs:
     timeout-minutes: 25
     container:
       image: ghcr.io/beshu-tech/deltaglider_proxy/builder:latest
+      # Raise the open-file limit. These jobs run on the self-hosted
+      # `k3s`-labelled Ryzen LXC runners, where the container inherits a low
+      # default nofile (~1024). The integration suite spawns ~35 test
+      # binaries in parallel, each with its own proxy + MinIO sockets, so the
+      # aggregate fd count blows past 1024 and surfaces as
+      # `ConnectError("tcp open error", Os code 24 "Too many open files")`.
+      # The LXC host also bumps nofile (lxc.prlimit.nofile) — this is the
+      # belt-and-suspenders so the workflow is self-documenting and portable.
+      options: --ulimit nofile=1048576:1048576
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -630,6 +729,15 @@ jobs:
     timeout-minutes: 10
     container:
       image: ghcr.io/beshu-tech/deltaglider_proxy/builder:latest
+      # Raise the open-file limit. These jobs run on the self-hosted
+      # `k3s`-labelled Ryzen LXC runners, where the container inherits a low
+      # default nofile (~1024). The integration suite spawns ~35 test
+      # binaries in parallel, each with its own proxy + MinIO sockets, so the
+      # aggregate fd count blows past 1024 and surfaces as
+      # `ConnectError("tcp open error", Os code 24 "Too many open files")`.
+      # The LXC host also bumps nofile (lxc.prlimit.nofile) — this is the
+      # belt-and-suspenders so the workflow is self-documenting and portable.
+      options: --ulimit nofile=1048576:1048576
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,47 @@
 
 ## Unreleased
 
+### Added — event-driven replication
+
+- **Replication now reacts to object mutations in near-real time.** Previously
+  replication was pure-poll: a timer did a full `list + HEAD` diff every tick,
+  scaling with bucket size rather than change rate. Object mutations
+  (PUT / DELETE / COPY / CompleteMultipartUpload) are now appended to the durable
+  `event_outbox` and drained by a per-process consumer that fans each key out to
+  the matching replication rules. The per-rule `interval` is repurposed as a slow
+  (default **24h**) full-reconcile safety net — events are the primary trigger.
+  - Pub/sub via a per-listener cursor over the append-only outbox: webhook
+    delivery and replication keep independent cursors and never contend.
+  - Per-key compaction collapses a burst of events for one key into a single
+    liveness verdict; idempotency stays in one place (the planner + a dest HEAD),
+    shared with reconcile — no new per-key sync table.
+  - At-least-once delivery: the cursor advances only to the highest contiguous
+    fully-handled event id; reconcile backstops the rest.
+  - The webhook pruner clamps its delete floor to the smallest **active** listener
+    cursor, so a stuck or disabled consumer can no longer pin the outbox and let
+    it grow without bound.
+
+### Added — Webhook delivery GUI
+
+- **Webhook (event-delivery) config is now editable from the admin UI** at
+  Configuration → Advanced → Webhook delivery — the last config surface that was
+  YAML/env-only. Enable switch, endpoint list, auth-header editor, retry /
+  retention / batching tuning, and a live delivery-status strip linking to the
+  Event Outbox viewer.
+- **Header secrets are masked and preserved.** Header values are shown masked in
+  the GUI and in every export; leaving a masked value untouched preserves the
+  real token on save (both the section-PUT and the full-document export→apply
+  paths), while a removed header is deleted and a renamed-but-not-retyped secret
+  is blocked rather than silently dropped.
+
+### Fixed — CI
+
+- **Self-hosted runner "Too many open files".** The CI integration job runs ~35
+  test binaries in parallel inside Ryzen LXC runners whose nested dockerd
+  defaulted to a 1024 nofile limit; the aggregate fd count overflowed it. Raised
+  the limit at the dockerd, workflow (`--ulimit`), and test-harness (seed
+  concurrency cap) layers.
+
 ## v1.1.2 — 2026-06-02
 
 ### Fixed — hardening (from an adversarial Rust audit)

--- a/demo/s3-browser/ui/package.json
+++ b/demo/s3-browser/ui/package.json
@@ -39,6 +39,7 @@
     "test:lifecycle-helpers": "node scripts/lifecycle-helpers-regression-test.mjs",
     "test:upload-telemetry": "node scripts/upload-telemetry-regression-test.mjs",
     "test:page-size": "node scripts/page-size-regression-test.mjs",
+    "test:webhook-delivery-payload": "node scripts/webhook-delivery-payload-regression-test.mjs",
     "e2e": "playwright test",
     "typecheck": "tsc --noEmit",
     "knip": "knip"

--- a/demo/s3-browser/ui/scripts/webhook-delivery-payload-regression-test.mjs
+++ b/demo/s3-browser/ui/scripts/webhook-delivery-payload-regression-test.mjs
@@ -18,106 +18,164 @@ async function loadModule(relPath, fileName) {
 }
 
 const url = await loadModule('../src/components/webhookDeliveryPayload.ts', 'webhookDeliveryPayload.ts');
-const {
-  WEBHOOK_REDACTED_SENTINEL,
-  DEFAULT_EVENT_DELIVERY,
-  normalizeEventDelivery,
-  buildEventDeliveryPayload,
-} = await import(url);
+const { formFromWire, buildPayloadFromForm } = await import(url);
 
-const SENTINEL = WEBHOOK_REDACTED_SENTINEL;
+// Must equal REDACTED_SENTINEL in src/config.rs and the constant in
+// webhookDeliveryPayload.ts — the cross-language secret-mask sentinel.
+const SENTINEL = '__redacted__';
 
-// ── normalizeEventDelivery: legacy webhook_url folds into the list ──
-{
-  const norm = normalizeEventDelivery({ webhook_url: 'https://a.example/in', webhook_urls: ['https://b.example/in'] });
-  assert.deepEqual(norm.webhook_urls, ['https://a.example/in', 'https://b.example/in'], 'legacy url first, deduped');
-}
-{
-  const norm = normalizeEventDelivery(undefined);
-  assert.deepEqual(norm, DEFAULT_EVENT_DELIVERY, 'undefined → defaults');
-}
-{
-  // dedupe: legacy url equal to a list entry must not double.
-  const norm = normalizeEventDelivery({ webhook_url: 'https://x.example/h', webhook_urls: ['https://x.example/h'] });
-  assert.deepEqual(norm.webhook_urls, ['https://x.example/h']);
+// Deterministic id generator (the panel injects a per-instance counter).
+function mkIdGen() {
+  let n = 0;
+  return () => `r${n++}`;
 }
 
-// ── header DELETE must emit explicit null (RFC 7396) ──
-{
-  const baseline = normalizeEventDelivery({ webhook_headers: { Authorization: SENTINEL, 'X-Env': SENTINEL } });
-  // operator removed X-Env, left Authorization untouched (sentinel).
-  const local = { ...baseline, webhook_headers: { Authorization: SENTINEL } };
-  const res = buildEventDeliveryPayload(local, baseline);
-  assert.ok(res.ok, `expected ok, got ${JSON.stringify(res.errors)}`);
-  const h = res.body.event_delivery.webhook_headers;
-  assert.equal(h['X-Env'], null, 'removed header must be null (delete)');
-  assert.equal(h['Authorization'], SENTINEL, 'untouched header stays sentinel (server preserves)');
-  // JSON round-trip must keep the null key.
-  const rt = JSON.parse(JSON.stringify(res.body));
-  assert.ok('X-Env' in rt.event_delivery.webhook_headers, 'null delete-key must survive JSON.stringify');
+// Load a form from a server wire body, optionally mutate it, then build the
+// payload — exactly the panel's pick → edit → toPayload pipeline.
+function buildFromWire(wire, mutate) {
+  const form = formFromWire(wire, mkIdGen());
+  if (mutate) mutate(form);
+  return buildPayloadFromForm(form);
+}
+function headers(res) {
+  return res.body.event_delivery.webhook_headers;
 }
 
-// ── retyped secret passes through; new secret added ──
+// ── legacy webhook_url folds into the endpoint list (deduped, legacy first) ──
 {
-  const baseline = normalizeEventDelivery({ webhook_headers: { Authorization: SENTINEL } });
-  const local = { ...baseline, webhook_headers: { Authorization: 'Bearer NEW', 'X-Trace': 'on' } };
-  const res = buildEventDeliveryPayload(local, baseline);
+  const form = formFromWire(
+    { webhook_url: 'https://a.example/in', webhook_urls: ['https://b.example/in'] },
+    mkIdGen()
+  );
+  assert.deepEqual(
+    form.urlRows.map((r) => r.url),
+    ['https://a.example/in', 'https://b.example/in'],
+    'legacy url first, deduped'
+  );
+}
+{
+  const form = formFromWire(
+    { webhook_url: 'https://x.example/h', webhook_urls: ['https://x.example/h'] },
+    mkIdGen()
+  );
+  assert.deepEqual(form.urlRows.map((r) => r.url), ['https://x.example/h'], 'dedupe legacy vs list');
+}
+
+// ── legacy webhook_url is always cleared on save; list preserved ──
+{
+  const res = buildFromWire({ webhook_url: 'https://legacy.example/h' });
   assert.ok(res.ok);
-  assert.equal(res.body.event_delivery.webhook_headers['Authorization'], 'Bearer NEW');
-  assert.equal(res.body.event_delivery.webhook_headers['X-Trace'], 'on');
-}
-
-// ── legacy webhook_url is always cleared on save ──
-{
-  const baseline = normalizeEventDelivery({ webhook_url: 'https://legacy.example/h' });
-  const local = { ...baseline };
-  const res = buildEventDeliveryPayload(local, baseline);
-  assert.ok(res.ok);
-  assert.equal(res.body.event_delivery.webhook_url, null, 'legacy webhook_url must be cleared');
+  assert.equal(res.body.event_delivery.webhook_url, null, 'legacy webhook_url cleared');
   assert.deepEqual(res.body.event_delivery.webhook_urls, ['https://legacy.example/h']);
+}
+
+// ── header DELETE emits explicit null (RFC 7396) for a REMOVED row ──
+{
+  const res = buildFromWire(
+    { webhook_headers: { Authorization: SENTINEL, 'X-Env': SENTINEL } },
+    (f) => {
+      f.headerRows = f.headerRows.filter((r) => r.name !== 'X-Env'); // operator removed it
+    }
+  );
+  assert.ok(res.ok, JSON.stringify(res.errors));
+  assert.equal(headers(res)['X-Env'], null, 'removed header → null delete');
+  assert.equal(headers(res)['Authorization'], SENTINEL, 'untouched header stays sentinel');
+  const rt = JSON.parse(JSON.stringify(res.body));
+  assert.ok('X-Env' in rt.event_delivery.webhook_headers, 'null delete-key survives JSON.stringify');
+}
+
+// ── untouched masked secret passes through as sentinel (server restores) ──
+{
+  const res = buildFromWire({ webhook_headers: { Authorization: SENTINEL } });
+  assert.ok(res.ok);
+  assert.equal(headers(res)['Authorization'], SENTINEL);
+}
+
+// ── retyped secret + new header pass through with real values ──
+{
+  const res = buildFromWire({ webhook_headers: { Authorization: SENTINEL } }, (f) => {
+    f.headerRows[0].value = 'Bearer NEW';
+    f.headerRows[0].masked = false; // typing unmasks
+    f.headerRows.push({ id: 'x', name: 'X-Trace', value: 'on', origName: '', masked: false });
+  });
+  assert.ok(res.ok);
+  assert.equal(headers(res)['Authorization'], 'Bearer NEW');
+  assert.equal(headers(res)['X-Trace'], 'on');
+}
+
+// ── RENAME a still-masked header is BLOCKED (adversarial #2) ──
+{
+  const res = buildFromWire({ webhook_headers: { Authorizaton: SENTINEL } }, (f) => {
+    f.headerRows[0].name = 'Authorization'; // fix typo without re-entering value
+  });
+  assert.ok(!res.ok, 'rename-while-masked must be blocked');
+  assert.ok(
+    res.errors.some((e) => /re-enter/i.test(e) || /re-type/i.test(e)),
+    'error must tell operator to re-type the value'
+  );
+}
+
+// ── rename WITH a re-typed value is allowed; old name deleted ──
+{
+  const res = buildFromWire({ webhook_headers: { Authorizaton: SENTINEL } }, (f) => {
+    f.headerRows[0].name = 'Authorization';
+    f.headerRows[0].value = 'Bearer real';
+    f.headerRows[0].masked = false;
+  });
+  assert.ok(res.ok, JSON.stringify(res.errors));
+  assert.equal(headers(res)['Authorization'], 'Bearer real');
+  assert.equal(headers(res)['Authorizaton'], null, 'old name deleted');
+}
+
+// ── in-progress empty rows are ignored, not errors ──
+{
+  const res = buildFromWire({}, (f) => {
+    f.urlRows = [{ id: 'a', url: '' }];
+    f.headerRows = [{ id: 'b', name: '', value: '', origName: '', masked: false }];
+  });
+  assert.ok(res.ok, `empty in-progress rows must not error, got ${JSON.stringify(res.errors)}`);
+  assert.deepEqual(res.body.event_delivery.webhook_urls, []);
 }
 
 // ── enabling with zero endpoints is rejected (usability trap) ──
 {
-  const baseline = normalizeEventDelivery({});
-  const local = { ...baseline, enabled: true, webhook_urls: [] };
-  const res = buildEventDeliveryPayload(local, baseline);
-  assert.ok(!res.ok, 'enabled + no endpoint must fail');
-  assert.ok(res.errors.some((e) => /no endpoint/i.test(e)), 'error should mention no endpoint');
+  const res = buildFromWire({}, (f) => {
+    f.enabled = true;
+    f.urlRows = [];
+  });
+  assert.ok(!res.ok && res.errors.some((e) => /no endpoint/i.test(e)), 'enabled + no endpoint must fail');
 }
 
-// ── duration validation ──
+// ── duration validation: simple + compound humantime (1h30m) + word forms ──
 {
-  const baseline = normalizeEventDelivery({});
-  const ok = buildEventDeliveryPayload({ ...baseline, tick_interval: '30s', retry_max: '5m', delivered_retention: '0s' }, baseline);
-  assert.ok(ok.ok, `valid durations should pass, got ${JSON.stringify(ok.errors)}`);
-  const bad = buildEventDeliveryPayload({ ...baseline, tick_interval: '30' }, baseline);
-  assert.ok(!bad.ok && bad.errors.some((e) => /tick_interval/.test(e)), 'bare number duration rejected');
-  const bad2 = buildEventDeliveryPayload({ ...baseline, request_timeout: '5 minutes' }, baseline);
-  assert.ok(!bad2.ok, 'prose duration rejected');
+  assert.ok(buildFromWire({}, (f) => (f.tick_interval = '30s')).ok, '30s ok');
+  assert.ok(buildFromWire({}, (f) => (f.delivered_retention = '0s')).ok, '0s ok (disable prune)');
+  assert.ok(buildFromWire({}, (f) => (f.retry_max = '1h30m')).ok, 'compound 1h30m ok (adversarial #4)');
+  assert.ok(buildFromWire({}, (f) => (f.tick_interval = '1500ms')).ok, '1500ms ok');
+  assert.ok(buildFromWire({}, (f) => (f.delivered_retention = '7days')).ok, '7days word-form ok');
+  const bad = buildFromWire({}, (f) => (f.tick_interval = '30'));
+  assert.ok(!bad.ok && bad.errors.some((e) => /tick_interval/.test(e)), 'bare number rejected');
+  assert.ok(!buildFromWire({}, (f) => (f.request_timeout = '5 minutes')).ok, 'prose duration rejected');
 }
 
 // ── numeric range validation ──
 {
-  const baseline = normalizeEventDelivery({});
-  const bad = buildEventDeliveryPayload({ ...baseline, batch_size: 0 }, baseline);
+  const bad = buildFromWire({}, (f) => (f.batch_size = 0));
   assert.ok(!bad.ok && bad.errors.some((e) => /batch_size/.test(e)), 'batch_size 0 rejected (min 1)');
-  const bad2 = buildEventDeliveryPayload({ ...baseline, max_attempts: -1 }, baseline);
-  assert.ok(!bad2.ok, 'negative max_attempts rejected');
+  assert.ok(!buildFromWire({}, (f) => (f.max_attempts = -1)).ok, 'negative max_attempts rejected');
 }
 
-// ── invalid endpoint URL rejected ──
+// ── invalid endpoint URL + invalid header name rejected ──
 {
-  const baseline = normalizeEventDelivery({});
-  const res = buildEventDeliveryPayload({ ...baseline, enabled: true, webhook_urls: ['not-a-url'] }, baseline);
-  assert.ok(!res.ok && res.errors.some((e) => /not a valid/i.test(e)), 'junk URL rejected');
-}
-
-// ── invalid header name rejected ──
-{
-  const baseline = normalizeEventDelivery({});
-  const res = buildEventDeliveryPayload({ ...baseline, webhook_headers: { 'Bad Header': 'v' } }, baseline);
-  assert.ok(!res.ok && res.errors.some((e) => /invalid characters/i.test(e)), 'header name with space rejected');
+  const u = buildFromWire({}, (f) => {
+    f.enabled = true;
+    f.urlRows = [{ id: 'a', url: 'not-a-url' }];
+  });
+  assert.ok(!u.ok && u.errors.some((e) => /not a valid/i.test(e)), 'junk URL rejected');
+  const h = buildFromWire({}, (f) => {
+    f.headerRows = [{ id: 'b', name: 'Bad Header', value: 'v', origName: '', masked: false }];
+  });
+  assert.ok(!h.ok && h.errors.some((e) => /invalid characters/i.test(e)), 'header name with space rejected');
 }
 
 console.log('webhook-delivery-payload-regression-test: all assertions passed');

--- a/demo/s3-browser/ui/scripts/webhook-delivery-payload-regression-test.mjs
+++ b/demo/s3-browser/ui/scripts/webhook-delivery-payload-regression-test.mjs
@@ -1,0 +1,123 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import ts from 'typescript';
+
+// Transpile the pure payload helper (no React/antd) to an importable data: URL.
+async function loadModule(relPath, fileName) {
+  const url = new URL(relPath, import.meta.url);
+  const source = await readFile(url, 'utf8');
+  const { outputText } = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ES2020,
+      target: ts.ScriptTarget.ES2020,
+      importsNotUsedAsValues: ts.ImportsNotUsedAsValues.Remove,
+    },
+    fileName,
+  });
+  return `data:text/javascript;base64,${Buffer.from(outputText).toString('base64')}`;
+}
+
+const url = await loadModule('../src/components/webhookDeliveryPayload.ts', 'webhookDeliveryPayload.ts');
+const {
+  WEBHOOK_REDACTED_SENTINEL,
+  DEFAULT_EVENT_DELIVERY,
+  normalizeEventDelivery,
+  buildEventDeliveryPayload,
+} = await import(url);
+
+const SENTINEL = WEBHOOK_REDACTED_SENTINEL;
+
+// ── normalizeEventDelivery: legacy webhook_url folds into the list ──
+{
+  const norm = normalizeEventDelivery({ webhook_url: 'https://a.example/in', webhook_urls: ['https://b.example/in'] });
+  assert.deepEqual(norm.webhook_urls, ['https://a.example/in', 'https://b.example/in'], 'legacy url first, deduped');
+}
+{
+  const norm = normalizeEventDelivery(undefined);
+  assert.deepEqual(norm, DEFAULT_EVENT_DELIVERY, 'undefined → defaults');
+}
+{
+  // dedupe: legacy url equal to a list entry must not double.
+  const norm = normalizeEventDelivery({ webhook_url: 'https://x.example/h', webhook_urls: ['https://x.example/h'] });
+  assert.deepEqual(norm.webhook_urls, ['https://x.example/h']);
+}
+
+// ── header DELETE must emit explicit null (RFC 7396) ──
+{
+  const baseline = normalizeEventDelivery({ webhook_headers: { Authorization: SENTINEL, 'X-Env': SENTINEL } });
+  // operator removed X-Env, left Authorization untouched (sentinel).
+  const local = { ...baseline, webhook_headers: { Authorization: SENTINEL } };
+  const res = buildEventDeliveryPayload(local, baseline);
+  assert.ok(res.ok, `expected ok, got ${JSON.stringify(res.errors)}`);
+  const h = res.body.event_delivery.webhook_headers;
+  assert.equal(h['X-Env'], null, 'removed header must be null (delete)');
+  assert.equal(h['Authorization'], SENTINEL, 'untouched header stays sentinel (server preserves)');
+  // JSON round-trip must keep the null key.
+  const rt = JSON.parse(JSON.stringify(res.body));
+  assert.ok('X-Env' in rt.event_delivery.webhook_headers, 'null delete-key must survive JSON.stringify');
+}
+
+// ── retyped secret passes through; new secret added ──
+{
+  const baseline = normalizeEventDelivery({ webhook_headers: { Authorization: SENTINEL } });
+  const local = { ...baseline, webhook_headers: { Authorization: 'Bearer NEW', 'X-Trace': 'on' } };
+  const res = buildEventDeliveryPayload(local, baseline);
+  assert.ok(res.ok);
+  assert.equal(res.body.event_delivery.webhook_headers['Authorization'], 'Bearer NEW');
+  assert.equal(res.body.event_delivery.webhook_headers['X-Trace'], 'on');
+}
+
+// ── legacy webhook_url is always cleared on save ──
+{
+  const baseline = normalizeEventDelivery({ webhook_url: 'https://legacy.example/h' });
+  const local = { ...baseline };
+  const res = buildEventDeliveryPayload(local, baseline);
+  assert.ok(res.ok);
+  assert.equal(res.body.event_delivery.webhook_url, null, 'legacy webhook_url must be cleared');
+  assert.deepEqual(res.body.event_delivery.webhook_urls, ['https://legacy.example/h']);
+}
+
+// ── enabling with zero endpoints is rejected (usability trap) ──
+{
+  const baseline = normalizeEventDelivery({});
+  const local = { ...baseline, enabled: true, webhook_urls: [] };
+  const res = buildEventDeliveryPayload(local, baseline);
+  assert.ok(!res.ok, 'enabled + no endpoint must fail');
+  assert.ok(res.errors.some((e) => /no endpoint/i.test(e)), 'error should mention no endpoint');
+}
+
+// ── duration validation ──
+{
+  const baseline = normalizeEventDelivery({});
+  const ok = buildEventDeliveryPayload({ ...baseline, tick_interval: '30s', retry_max: '5m', delivered_retention: '0s' }, baseline);
+  assert.ok(ok.ok, `valid durations should pass, got ${JSON.stringify(ok.errors)}`);
+  const bad = buildEventDeliveryPayload({ ...baseline, tick_interval: '30' }, baseline);
+  assert.ok(!bad.ok && bad.errors.some((e) => /tick_interval/.test(e)), 'bare number duration rejected');
+  const bad2 = buildEventDeliveryPayload({ ...baseline, request_timeout: '5 minutes' }, baseline);
+  assert.ok(!bad2.ok, 'prose duration rejected');
+}
+
+// ── numeric range validation ──
+{
+  const baseline = normalizeEventDelivery({});
+  const bad = buildEventDeliveryPayload({ ...baseline, batch_size: 0 }, baseline);
+  assert.ok(!bad.ok && bad.errors.some((e) => /batch_size/.test(e)), 'batch_size 0 rejected (min 1)');
+  const bad2 = buildEventDeliveryPayload({ ...baseline, max_attempts: -1 }, baseline);
+  assert.ok(!bad2.ok, 'negative max_attempts rejected');
+}
+
+// ── invalid endpoint URL rejected ──
+{
+  const baseline = normalizeEventDelivery({});
+  const res = buildEventDeliveryPayload({ ...baseline, enabled: true, webhook_urls: ['not-a-url'] }, baseline);
+  assert.ok(!res.ok && res.errors.some((e) => /not a valid/i.test(e)), 'junk URL rejected');
+}
+
+// ── invalid header name rejected ──
+{
+  const baseline = normalizeEventDelivery({});
+  const res = buildEventDeliveryPayload({ ...baseline, webhook_headers: { 'Bad Header': 'v' } }, baseline);
+  assert.ok(!res.ok && res.errors.some((e) => /invalid characters/i.test(e)), 'header name with space rejected');
+}
+
+console.log('webhook-delivery-payload-regression-test: all assertions passed');

--- a/demo/s3-browser/ui/src/components/AdminPage.tsx
+++ b/demo/s3-browser/ui/src/components/AdminPage.tsx
@@ -41,6 +41,7 @@ import {
   LoggingPanel,
   ConfigDbSyncPanel,
 } from './advancedPanels';
+import WebhookDeliveryPanel from './WebhookDeliveryPanel';
 import {
   AccessOverview,
   StorageOverview,
@@ -732,6 +733,14 @@ export default function AdminPage({ onBack, onSessionExpired, subPath, accountMe
         <>
           {header}
           <ConfigDbSyncPanel onSessionExpired={onSessionExpired} />
+        </>
+      );
+    }
+    if (adminPath === 'configuration/advanced/event-delivery') {
+      return (
+        <>
+          {header}
+          <WebhookDeliveryPanel onSessionExpired={onSessionExpired} />
         </>
       );
     }

--- a/demo/s3-browser/ui/src/components/WebhookDeliveryPanel.tsx
+++ b/demo/s3-browser/ui/src/components/WebhookDeliveryPanel.tsx
@@ -3,21 +3,24 @@
  * Wave 1 section API (`/api/admin/config/section/advanced`), mirroring the
  * other Advanced sub-panels.
  *
- * Secret handling: header VALUES are masked to WEBHOOK_REDACTED_SENTINEL on
- * GET. The value field shows a masked placeholder for an untouched secret;
- * typing replaces it. On save, untouched (sentinel) values pass through and
- * the server restores the real token; removed headers emit explicit `null`
- * (RFC 7396 delete) — both handled in `buildEventDeliveryPayload`.
+ * Single source of truth: the editor `value` IS the form state (rows + scalars)
+ * via `useSectionEditor`'s `pick`/`toPayload`. No parallel mirror — so discard,
+ * post-apply refresh, and re-mask all stay correct for free.
  *
- * Usability invariants enforced here (usability bugs ARE bugs):
- *  - enabling delivery with no endpoint is blocked with a clear message;
- *  - duration fields hint the accepted format; numeric ranges validated;
- *  - rows use stable ids so remove/re-add with the same key works;
- *  - the masked sentinel is never shown as a real value and never editable
- *    in place without an explicit "replace" gesture;
- *  - dirty-dot + ⌘S + discard all work via useSectionEditor.
+ * Secret handling: header VALUES are masked to WEBHOOK_REDACTED_SENTINEL on
+ * GET. A masked value shows a placeholder; typing replaces it. On save,
+ * untouched (sentinel) values pass through and the server restores the real
+ * token; removed headers emit explicit `null` (RFC 7396 delete). Renaming a
+ * still-masked header is BLOCKED (the secret can't follow the rename) — the
+ * operator must re-type the value or remove/re-add.
+ *
+ * Usability invariants (usability bugs ARE bugs): enabling with no endpoint is
+ * blocked; duration fields hint the format; numeric ranges validated; rows use
+ * stable ids; the masked sentinel is never shown or saved as a real value;
+ * dirty-dot + ⌘S + discard all work via useSectionEditor.
  */
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useMemo, useRef } from 'react';
+import { useEffect, useState } from 'react';
 import {
   Alert,
   Button,
@@ -28,28 +31,22 @@ import {
   Tag,
   Typography,
 } from 'antd';
-import {
-  ApiOutlined,
-  DeleteOutlined,
-  PlusOutlined,
-  SendOutlined,
-} from '@ant-design/icons';
+import { DeleteOutlined, PlusOutlined, SendOutlined } from '@ant-design/icons';
 import type { SectionApplyResponse } from '../adminApi';
 import { fetchEventOutbox } from '../adminApi';
 import { useCardStyles } from './shared-styles';
 import { useSectionEditor } from '../useSectionEditor';
-import { useApplyHandler } from '../useDirtySection';
 import { useNavigation } from '../NavigationContext';
 import SectionHeader from './SectionHeader';
 import FormField from './FormField';
 import ApplyDialog from './ApplyDialog';
 import { AdvancedDisclosure } from './ruleEditorFields';
 import {
-  WEBHOOK_REDACTED_SENTINEL,
-  DEFAULT_EVENT_DELIVERY,
-  normalizeEventDelivery,
-  buildEventDeliveryPayload,
-  type EventDeliveryConfig,
+  formFromWire,
+  buildPayloadFromForm,
+  type WebhookFormState,
+  type WebhookHeaderRow,
+  type WebhookUrlRow,
   type AdvancedSectionWebhookBody,
 } from './webhookDeliveryPayload';
 
@@ -59,23 +56,22 @@ interface Props {
   onSessionExpired?: () => void;
 }
 
-// Stable-id rows for the endpoint + header editors (avoids the array-index
-// key bug class — see ConditionPrefixInput / admin_editor_bug_class).
-interface UrlRow {
-  id: string;
-  url: string;
-}
-interface HeaderRow {
-  id: string;
-  name: string;
-  value: string;
-  // True while the value is still the server-masked sentinel (untouched
-  // secret). Cleared the moment the operator edits the value.
-  masked: boolean;
-}
-
-let _rowSeq = 0;
-const nextId = () => `r${_rowSeq++}`;
+const EMPTY_FORM: WebhookFormState = {
+  enabled: false,
+  urlRows: [],
+  headerRows: [],
+  loadedHeaderNames: [],
+  tick_interval: '10s',
+  batch_size: 50,
+  request_timeout: '5s',
+  max_attempts: 8,
+  retry_base: '5s',
+  retry_max: '5m',
+  stale_claim_after: '60s',
+  delivered_retention: '24h',
+  delivered_max_rows: 10000,
+  prune_batch: 100,
+};
 
 function PanelShell({ children }: { children: React.ReactNode }) {
   return (
@@ -98,9 +94,14 @@ export default function WebhookDeliveryPanel({ onSessionExpired }: Props) {
   const { cardStyle, inputRadius } = useCardStyles();
   const nav = useNavigation();
 
+  // Per-instance row-id counter (no module global) — only used for React keys
+  // within this panel instance.
+  const seqRef = useRef(0);
+  const nextId = useMemo(() => () => `r${seqRef.current++}`, []);
+
   const {
-    value,
-    setValue,
+    value: form,
+    setValue: setForm,
     isDirty,
     discard,
     loading,
@@ -111,56 +112,23 @@ export default function WebhookDeliveryPanel({ onSessionExpired }: Props) {
     runApply: editorRunApply,
     cancelApply,
     confirmApply,
-  } = useSectionEditor<AdvancedSectionWebhookBody, EventDeliveryConfig>({
+  } = useSectionEditor<AdvancedSectionWebhookBody, WebhookFormState>({
     section: 'advanced',
     dirtyKey: 'configuration/advanced/event-delivery',
-    initial: DEFAULT_EVENT_DELIVERY,
+    initial: EMPTY_FORM,
     onSessionExpired,
     noun: 'webhook delivery',
-    pick: (body) => normalizeEventDelivery(body.event_delivery),
-    // Guarded runApply below blocks on validation failure, so this only
-    // runs for a valid config. Baseline diff for header deletes is computed
-    // against the loaded value snapshot (`baselineRef`).
+    pick: (body) => formFromWire(body.event_delivery, nextId),
+    // Guarded runApply below blocks on validation failure, so this only runs
+    // for a valid form; `{}` is the unreachable type-non-null fallback.
     toPayload: (v) => {
-      const res = buildEventDeliveryPayload(v, baselineRef.current);
+      const res = buildPayloadFromForm(v);
       return res.ok ? (res.body as AdvancedSectionWebhookBody) : {};
     },
   });
 
-  // Snapshot of the server-loaded value, used to diff header DELETES.
-  const baselineRef = useRef<EventDeliveryConfig>(DEFAULT_EVENT_DELIVERY);
-  // Local row state derived from `value` on load; we keep rows in component
-  // state (with stable ids) and sync back to `value` on every edit.
-  const [urlRows, setUrlRows] = useState<UrlRow[]>([]);
-  const [headerRows, setHeaderRows] = useState<HeaderRow[]>([]);
-  const [validationErrors, setValidationErrors] = useState<string[]>([]);
-  const initializedRef = useRef(false);
-
-  // Initialize rows once when the server value first loads.
-  useEffect(() => {
-    if (loading || initializedRef.current) return;
-    initializedRef.current = true;
-    baselineRef.current = value;
-    setUrlRows(value.webhook_urls.map((url) => ({ id: nextId(), url })));
-    setHeaderRows(
-      Object.entries(value.webhook_headers).map(([name, v]) => ({
-        id: nextId(),
-        name,
-        value: v,
-        masked: v === WEBHOOK_REDACTED_SENTINEL,
-      }))
-    );
-  }, [loading, value]);
-
-  // After a successful apply, re-baseline so the next edit diffs correctly.
-  useEffect(() => {
-    if (!isDirty && initializedRef.current) {
-      baselineRef.current = value;
-    }
-  }, [isDirty, value]);
-
-  // Live delivery status strip.
-  const [outboxCounts, setOutboxCounts] = useState<{
+  // Live delivery status strip (best-effort, read-only).
+  const [outbox, setOutbox] = useState<{
     pending: number;
     failed: number;
     enabled: boolean;
@@ -171,99 +139,64 @@ export default function WebhookDeliveryPanel({ onSessionExpired }: Props) {
     fetchEventOutbox(1)
       .then((r) => {
         if (!alive) return;
-        setOutboxCounts({
+        setOutbox({
           pending: r.counts.pending,
           failed: r.counts.failed,
           enabled: r.delivery_enabled,
           active: r.delivery_active,
         });
       })
-      .catch(() => {
-        /* status strip is best-effort */
-      });
+      .catch(() => {});
     return () => {
       alive = false;
     };
   }, []);
 
-  // Push row state back into the editor value (so dirty + payload track it).
-  const syncToValue = (
-    nextUrls: UrlRow[],
-    nextHeaders: HeaderRow[],
-    patch?: Partial<EventDeliveryConfig>
-  ) => {
-    const webhook_urls = nextUrls.map((r) => r.url.trim()).filter((u) => u.length > 0);
-    const webhook_headers: Record<string, string> = {};
-    for (const h of nextHeaders) {
-      const name = h.name.trim();
-      if (name) webhook_headers[name] = h.value;
-    }
-    setValue({ ...value, ...patch, webhook_urls, webhook_headers });
-  };
+  // ── Row + field mutators (edit the editor value directly) ──
+  const setField = (patch: Partial<WebhookFormState>) => setForm({ ...form, ...patch });
 
-  const updateUrl = (id: string, url: string) => {
-    const next = urlRows.map((r) => (r.id === id ? { ...r, url } : r));
-    setUrlRows(next);
-    syncToValue(next, headerRows);
-  };
-  const addUrl = () => {
-    const next = [...urlRows, { id: nextId(), url: '' }];
-    setUrlRows(next);
-    syncToValue(next, headerRows);
-  };
-  const removeUrl = (id: string) => {
-    const next = urlRows.filter((r) => r.id !== id);
-    setUrlRows(next);
-    syncToValue(next, headerRows);
-  };
+  const updateUrl = (id: string, url: string) =>
+    setField({ urlRows: form.urlRows.map((r) => (r.id === id ? { ...r, url } : r)) });
+  const addUrl = () =>
+    setField({ urlRows: [...form.urlRows, { id: nextId(), url: '' } as WebhookUrlRow] });
+  const removeUrl = (id: string) =>
+    setField({ urlRows: form.urlRows.filter((r) => r.id !== id) });
 
-  const updateHeader = (id: string, patch: Partial<HeaderRow>) => {
-    const next = headerRows.map((r) =>
-      r.id === id
-        ? {
-            ...r,
-            ...patch,
-            // Any value edit unmasks (it's now a real, operator-typed value).
-            masked: patch.value !== undefined ? false : r.masked,
-          }
-        : r
-    );
-    setHeaderRows(next);
-    syncToValue(urlRows, next);
-  };
-  const addHeader = () => {
-    const next = [...headerRows, { id: nextId(), name: '', value: '', masked: false }];
-    setHeaderRows(next);
-    syncToValue(urlRows, next);
-  };
-  const removeHeader = (id: string) => {
-    const next = headerRows.filter((r) => r.id !== id);
-    setHeaderRows(next);
-    syncToValue(urlRows, next);
-  };
+  const updateHeader = (id: string, patch: Partial<WebhookHeaderRow>) =>
+    setField({
+      headerRows: form.headerRows.map((r) =>
+        r.id === id
+          ? {
+              ...r,
+              ...patch,
+              // Editing the VALUE unmasks it (now a real, operator-typed value).
+              masked: patch.value !== undefined ? false : r.masked,
+            }
+          : r
+      ),
+    });
+  const addHeader = () =>
+    setField({
+      headerRows: [
+        ...form.headerRows,
+        { id: nextId(), name: '', value: '', origName: '', masked: false } as WebhookHeaderRow,
+      ],
+    });
+  const removeHeader = (id: string) =>
+    setField({ headerRows: form.headerRows.filter((r) => r.id !== id) });
 
-  const setField = (patch: Partial<EventDeliveryConfig>) =>
-    setValue({ ...value, ...patch });
-
-  // Guarded apply: validate client-side first; surface inline errors and
-  // block the ApplyDialog when invalid.
-  const runApply = () => {
-    const res = buildEventDeliveryPayload(value, baselineRef.current);
-    if (!res.ok) {
-      setValidationErrors(res.errors);
-      return;
-    }
-    setValidationErrors([]);
-    editorRunApply();
-  };
-  useApplyHandler('configuration/advanced/event-delivery', runApply, isDirty);
-
-  // Live validation preview (non-blocking) so the operator sees issues early.
+  // Live, non-blocking validation preview.
   const liveErrors = useMemo(() => {
     if (!isDirty) return [];
-    const res = buildEventDeliveryPayload(value, baselineRef.current);
+    const res = buildPayloadFromForm(form);
     return res.ok ? [] : res.errors;
-  }, [value, isDirty]);
+  }, [form, isDirty]);
+
+  const runApply = () => {
+    const res = buildPayloadFromForm(form);
+    if (!res.ok) return; // errors already shown via liveErrors
+    editorRunApply();
+  };
 
   if (error) return <Alert type="error" showIcon message="Failed to load" description={error} />;
   if (loading)
@@ -272,8 +205,6 @@ export default function WebhookDeliveryPanel({ onSessionExpired }: Props) {
         <Text type="secondary">Loading…</Text>
       </PanelShell>
     );
-
-  const shownErrors = validationErrors.length ? validationErrors : liveErrors;
 
   return (
     <PanelShell>
@@ -292,7 +223,7 @@ export default function WebhookDeliveryPanel({ onSessionExpired }: Props) {
                 type="primary"
                 size="small"
                 onClick={runApply}
-                disabled={applying}
+                disabled={applying || liveErrors.length > 0}
                 loading={applying}
               >
                 Apply
@@ -302,14 +233,14 @@ export default function WebhookDeliveryPanel({ onSessionExpired }: Props) {
         />
       )}
 
-      {shownErrors.length > 0 && (
+      {liveErrors.length > 0 && (
         <Alert
           type="error"
           showIcon
           message="Fix these before applying"
           description={
             <ul style={{ margin: 0, paddingLeft: 18 }}>
-              {shownErrors.map((e, i) => (
+              {liveErrors.map((e, i) => (
                 <li key={i}>{e}</li>
               ))}
             </ul>
@@ -317,21 +248,20 @@ export default function WebhookDeliveryPanel({ onSessionExpired }: Props) {
         />
       )}
 
-      {/* Live delivery status strip */}
-      {outboxCounts && (
+      {outbox && (
         <Alert
-          type={outboxCounts.active ? 'success' : 'info'}
+          type={outbox.active ? 'success' : 'info'}
           showIcon
           message={
             <Space size="middle" wrap>
               <span>
                 Delivery:{' '}
-                <Tag color={outboxCounts.active ? 'green' : outboxCounts.enabled ? 'orange' : 'default'}>
-                  {outboxCounts.active ? 'Active' : outboxCounts.enabled ? 'Enabled (no endpoint)' : 'Disabled'}
+                <Tag color={outbox.active ? 'green' : outbox.enabled ? 'orange' : 'default'}>
+                  {outbox.active ? 'Active' : outbox.enabled ? 'Enabled (no endpoint)' : 'Disabled'}
                 </Tag>
               </span>
-              <span>{outboxCounts.pending} pending</span>
-              <span>{outboxCounts.failed} failed</span>
+              <span>{outbox.pending} pending</span>
+              <span>{outbox.failed} failed</span>
               <Button
                 type="link"
                 size="small"
@@ -354,7 +284,7 @@ export default function WebhookDeliveryPanel({ onSessionExpired }: Props) {
         />
         <div style={{ marginTop: 16 }}>
           <FormField label="Enable delivery" yamlPath="advanced.event_delivery.enabled">
-            <Switch checked={value.enabled} onChange={(v) => setField({ enabled: v })} />
+            <Switch checked={form.enabled} onChange={(v) => setField({ enabled: v })} />
           </FormField>
 
           <FormField
@@ -363,12 +293,12 @@ export default function WebhookDeliveryPanel({ onSessionExpired }: Props) {
             helpText="HTTP(S) URLs that receive a deltaglider.event.v1 JSON payload. An event is marked delivered only after every endpoint returns 2xx."
           >
             <Space direction="vertical" style={{ width: '100%' }}>
-              {urlRows.length === 0 && (
+              {form.urlRows.length === 0 && (
                 <Text type="secondary" style={{ fontSize: 12 }}>
                   No endpoints. Add one to start delivering.
                 </Text>
               )}
-              {urlRows.map((row) => (
+              {form.urlRows.map((row) => (
                 <Space.Compact key={row.id} style={{ width: '100%' }}>
                   <Input
                     value={row.url}
@@ -395,12 +325,12 @@ export default function WebhookDeliveryPanel({ onSessionExpired }: Props) {
             helpText="Static headers sent with every request — e.g. an Authorization bearer token. Values are stored encrypted and shown masked; leave a masked value untouched to keep it."
           >
             <Space direction="vertical" style={{ width: '100%' }}>
-              {headerRows.length === 0 && (
+              {form.headerRows.length === 0 && (
                 <Text type="secondary" style={{ fontSize: 12 }}>
                   No headers.
                 </Text>
               )}
-              {headerRows.map((row) => (
+              {form.headerRows.map((row) => (
                 <Space.Compact key={row.id} style={{ width: '100%' }}>
                   <Input
                     value={row.name}
@@ -436,7 +366,7 @@ export default function WebhookDeliveryPanel({ onSessionExpired }: Props) {
             label="Tick interval"
             yamlPath="advanced.event_delivery.tick_interval"
             help="How often the dispatcher wakes to deliver due events."
-            value={value.tick_interval}
+            value={form.tick_interval}
             placeholder="10s"
             onChange={(v) => setField({ tick_interval: v })}
             inputRadius={inputRadius}
@@ -445,7 +375,7 @@ export default function WebhookDeliveryPanel({ onSessionExpired }: Props) {
             label="Batch size"
             yamlPath="advanced.event_delivery.batch_size"
             help="Max events claimed per tick (clamped 1–500)."
-            value={value.batch_size}
+            value={form.batch_size}
             min={1}
             max={500}
             onChange={(v) => setField({ batch_size: v })}
@@ -454,7 +384,7 @@ export default function WebhookDeliveryPanel({ onSessionExpired }: Props) {
             label="Request timeout"
             yamlPath="advanced.event_delivery.request_timeout"
             help="Per-endpoint HTTP timeout."
-            value={value.request_timeout}
+            value={form.request_timeout}
             placeholder="5s"
             onChange={(v) => setField({ request_timeout: v })}
             inputRadius={inputRadius}
@@ -463,7 +393,7 @@ export default function WebhookDeliveryPanel({ onSessionExpired }: Props) {
             label="Max attempts"
             yamlPath="advanced.event_delivery.max_attempts"
             help="Attempts before an event becomes permanently failed."
-            value={value.max_attempts}
+            value={form.max_attempts}
             min={1}
             onChange={(v) => setField({ max_attempts: v })}
           />
@@ -471,7 +401,7 @@ export default function WebhookDeliveryPanel({ onSessionExpired }: Props) {
             label="Retry base"
             yamlPath="advanced.event_delivery.retry_base"
             help="Initial retry delay; exponential backoff doubles it per attempt."
-            value={value.retry_base}
+            value={form.retry_base}
             placeholder="5s"
             onChange={(v) => setField({ retry_base: v })}
             inputRadius={inputRadius}
@@ -480,7 +410,7 @@ export default function WebhookDeliveryPanel({ onSessionExpired }: Props) {
             label="Retry max"
             yamlPath="advanced.event_delivery.retry_max"
             help="Ceiling for the backoff delay."
-            value={value.retry_max}
+            value={form.retry_max}
             placeholder="5m"
             onChange={(v) => setField({ retry_max: v })}
             inputRadius={inputRadius}
@@ -489,7 +419,7 @@ export default function WebhookDeliveryPanel({ onSessionExpired }: Props) {
             label="Stale claim after"
             yamlPath="advanced.event_delivery.stale_claim_after"
             help="In-progress claims older than this are reclaimable (crash recovery)."
-            value={value.stale_claim_after}
+            value={form.stale_claim_after}
             placeholder="60s"
             onChange={(v) => setField({ stale_claim_after: v })}
             inputRadius={inputRadius}
@@ -498,7 +428,7 @@ export default function WebhookDeliveryPanel({ onSessionExpired }: Props) {
             label="Delivered retention"
             yamlPath="advanced.event_delivery.delivered_retention"
             help="Delivered rows older than this are pruned. 0s keeps them until manually pruned."
-            value={value.delivered_retention}
+            value={form.delivered_retention}
             placeholder="24h"
             onChange={(v) => setField({ delivered_retention: v })}
             inputRadius={inputRadius}
@@ -507,7 +437,7 @@ export default function WebhookDeliveryPanel({ onSessionExpired }: Props) {
             label="Delivered max rows"
             yamlPath="advanced.event_delivery.delivered_max_rows"
             help="Cap on retained delivered rows (pending/failed never pruned by this)."
-            value={value.delivered_max_rows}
+            value={form.delivered_max_rows}
             min={0}
             onChange={(v) => setField({ delivered_max_rows: v })}
           />
@@ -515,7 +445,7 @@ export default function WebhookDeliveryPanel({ onSessionExpired }: Props) {
             label="Prune batch"
             yamlPath="advanced.event_delivery.prune_batch"
             help="Max delivered rows pruned per tick."
-            value={value.prune_batch}
+            value={form.prune_batch}
             min={0}
             onChange={(v) => setField({ prune_batch: v })}
           />
@@ -545,13 +475,9 @@ function DurationField(props: {
 }) {
   return (
     <FormField
-      label={
-        <>
-          {props.label} <ApiOutlined style={{ opacity: 0 }} />
-        </>
-      }
+      label={props.label}
       yamlPath={props.yamlPath}
-      helpText={`${props.help} Format: 30s, 5m, 24h.`}
+      helpText={`${props.help} Format: 30s, 5m, 24h (compound like 1h30m ok).`}
     >
       <Input
         value={props.value}

--- a/demo/s3-browser/ui/src/components/WebhookDeliveryPanel.tsx
+++ b/demo/s3-browser/ui/src/components/WebhookDeliveryPanel.tsx
@@ -1,0 +1,586 @@
+/**
+ * Webhook delivery panel — edits `advanced.event_delivery` through the
+ * Wave 1 section API (`/api/admin/config/section/advanced`), mirroring the
+ * other Advanced sub-panels.
+ *
+ * Secret handling: header VALUES are masked to WEBHOOK_REDACTED_SENTINEL on
+ * GET. The value field shows a masked placeholder for an untouched secret;
+ * typing replaces it. On save, untouched (sentinel) values pass through and
+ * the server restores the real token; removed headers emit explicit `null`
+ * (RFC 7396 delete) — both handled in `buildEventDeliveryPayload`.
+ *
+ * Usability invariants enforced here (usability bugs ARE bugs):
+ *  - enabling delivery with no endpoint is blocked with a clear message;
+ *  - duration fields hint the accepted format; numeric ranges validated;
+ *  - rows use stable ids so remove/re-add with the same key works;
+ *  - the masked sentinel is never shown as a real value and never editable
+ *    in place without an explicit "replace" gesture;
+ *  - dirty-dot + ⌘S + discard all work via useSectionEditor.
+ */
+import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  Alert,
+  Button,
+  Input,
+  InputNumber,
+  Space,
+  Switch,
+  Tag,
+  Typography,
+} from 'antd';
+import {
+  ApiOutlined,
+  DeleteOutlined,
+  PlusOutlined,
+  SendOutlined,
+} from '@ant-design/icons';
+import type { SectionApplyResponse } from '../adminApi';
+import { fetchEventOutbox } from '../adminApi';
+import { useCardStyles } from './shared-styles';
+import { useSectionEditor } from '../useSectionEditor';
+import { useApplyHandler } from '../useDirtySection';
+import { useNavigation } from '../NavigationContext';
+import SectionHeader from './SectionHeader';
+import FormField from './FormField';
+import ApplyDialog from './ApplyDialog';
+import { AdvancedDisclosure } from './ruleEditorFields';
+import {
+  WEBHOOK_REDACTED_SENTINEL,
+  DEFAULT_EVENT_DELIVERY,
+  normalizeEventDelivery,
+  buildEventDeliveryPayload,
+  type EventDeliveryConfig,
+  type AdvancedSectionWebhookBody,
+} from './webhookDeliveryPayload';
+
+const { Text } = Typography;
+
+interface Props {
+  onSessionExpired?: () => void;
+}
+
+// Stable-id rows for the endpoint + header editors (avoids the array-index
+// key bug class — see ConditionPrefixInput / admin_editor_bug_class).
+interface UrlRow {
+  id: string;
+  url: string;
+}
+interface HeaderRow {
+  id: string;
+  name: string;
+  value: string;
+  // True while the value is still the server-masked sentinel (untouched
+  // secret). Cleared the moment the operator edits the value.
+  masked: boolean;
+}
+
+let _rowSeq = 0;
+const nextId = () => `r${_rowSeq++}`;
+
+function PanelShell({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      style={{
+        maxWidth: 740,
+        margin: '0 auto',
+        padding: 'clamp(16px, 3vw, 24px)',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 16,
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+export default function WebhookDeliveryPanel({ onSessionExpired }: Props) {
+  const { cardStyle, inputRadius } = useCardStyles();
+  const nav = useNavigation();
+
+  const {
+    value,
+    setValue,
+    isDirty,
+    discard,
+    loading,
+    error,
+    applyOpen,
+    applyResponse,
+    applying,
+    runApply: editorRunApply,
+    cancelApply,
+    confirmApply,
+  } = useSectionEditor<AdvancedSectionWebhookBody, EventDeliveryConfig>({
+    section: 'advanced',
+    dirtyKey: 'configuration/advanced/event-delivery',
+    initial: DEFAULT_EVENT_DELIVERY,
+    onSessionExpired,
+    noun: 'webhook delivery',
+    pick: (body) => normalizeEventDelivery(body.event_delivery),
+    // Guarded runApply below blocks on validation failure, so this only
+    // runs for a valid config. Baseline diff for header deletes is computed
+    // against the loaded value snapshot (`baselineRef`).
+    toPayload: (v) => {
+      const res = buildEventDeliveryPayload(v, baselineRef.current);
+      return res.ok ? (res.body as AdvancedSectionWebhookBody) : {};
+    },
+  });
+
+  // Snapshot of the server-loaded value, used to diff header DELETES.
+  const baselineRef = useRef<EventDeliveryConfig>(DEFAULT_EVENT_DELIVERY);
+  // Local row state derived from `value` on load; we keep rows in component
+  // state (with stable ids) and sync back to `value` on every edit.
+  const [urlRows, setUrlRows] = useState<UrlRow[]>([]);
+  const [headerRows, setHeaderRows] = useState<HeaderRow[]>([]);
+  const [validationErrors, setValidationErrors] = useState<string[]>([]);
+  const initializedRef = useRef(false);
+
+  // Initialize rows once when the server value first loads.
+  useEffect(() => {
+    if (loading || initializedRef.current) return;
+    initializedRef.current = true;
+    baselineRef.current = value;
+    setUrlRows(value.webhook_urls.map((url) => ({ id: nextId(), url })));
+    setHeaderRows(
+      Object.entries(value.webhook_headers).map(([name, v]) => ({
+        id: nextId(),
+        name,
+        value: v,
+        masked: v === WEBHOOK_REDACTED_SENTINEL,
+      }))
+    );
+  }, [loading, value]);
+
+  // After a successful apply, re-baseline so the next edit diffs correctly.
+  useEffect(() => {
+    if (!isDirty && initializedRef.current) {
+      baselineRef.current = value;
+    }
+  }, [isDirty, value]);
+
+  // Live delivery status strip.
+  const [outboxCounts, setOutboxCounts] = useState<{
+    pending: number;
+    failed: number;
+    enabled: boolean;
+    active: boolean;
+  } | null>(null);
+  useEffect(() => {
+    let alive = true;
+    fetchEventOutbox(1)
+      .then((r) => {
+        if (!alive) return;
+        setOutboxCounts({
+          pending: r.counts.pending,
+          failed: r.counts.failed,
+          enabled: r.delivery_enabled,
+          active: r.delivery_active,
+        });
+      })
+      .catch(() => {
+        /* status strip is best-effort */
+      });
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  // Push row state back into the editor value (so dirty + payload track it).
+  const syncToValue = (
+    nextUrls: UrlRow[],
+    nextHeaders: HeaderRow[],
+    patch?: Partial<EventDeliveryConfig>
+  ) => {
+    const webhook_urls = nextUrls.map((r) => r.url.trim()).filter((u) => u.length > 0);
+    const webhook_headers: Record<string, string> = {};
+    for (const h of nextHeaders) {
+      const name = h.name.trim();
+      if (name) webhook_headers[name] = h.value;
+    }
+    setValue({ ...value, ...patch, webhook_urls, webhook_headers });
+  };
+
+  const updateUrl = (id: string, url: string) => {
+    const next = urlRows.map((r) => (r.id === id ? { ...r, url } : r));
+    setUrlRows(next);
+    syncToValue(next, headerRows);
+  };
+  const addUrl = () => {
+    const next = [...urlRows, { id: nextId(), url: '' }];
+    setUrlRows(next);
+    syncToValue(next, headerRows);
+  };
+  const removeUrl = (id: string) => {
+    const next = urlRows.filter((r) => r.id !== id);
+    setUrlRows(next);
+    syncToValue(next, headerRows);
+  };
+
+  const updateHeader = (id: string, patch: Partial<HeaderRow>) => {
+    const next = headerRows.map((r) =>
+      r.id === id
+        ? {
+            ...r,
+            ...patch,
+            // Any value edit unmasks (it's now a real, operator-typed value).
+            masked: patch.value !== undefined ? false : r.masked,
+          }
+        : r
+    );
+    setHeaderRows(next);
+    syncToValue(urlRows, next);
+  };
+  const addHeader = () => {
+    const next = [...headerRows, { id: nextId(), name: '', value: '', masked: false }];
+    setHeaderRows(next);
+    syncToValue(urlRows, next);
+  };
+  const removeHeader = (id: string) => {
+    const next = headerRows.filter((r) => r.id !== id);
+    setHeaderRows(next);
+    syncToValue(urlRows, next);
+  };
+
+  const setField = (patch: Partial<EventDeliveryConfig>) =>
+    setValue({ ...value, ...patch });
+
+  // Guarded apply: validate client-side first; surface inline errors and
+  // block the ApplyDialog when invalid.
+  const runApply = () => {
+    const res = buildEventDeliveryPayload(value, baselineRef.current);
+    if (!res.ok) {
+      setValidationErrors(res.errors);
+      return;
+    }
+    setValidationErrors([]);
+    editorRunApply();
+  };
+  useApplyHandler('configuration/advanced/event-delivery', runApply, isDirty);
+
+  // Live validation preview (non-blocking) so the operator sees issues early.
+  const liveErrors = useMemo(() => {
+    if (!isDirty) return [];
+    const res = buildEventDeliveryPayload(value, baselineRef.current);
+    return res.ok ? [] : res.errors;
+  }, [value, isDirty]);
+
+  if (error) return <Alert type="error" showIcon message="Failed to load" description={error} />;
+  if (loading)
+    return (
+      <PanelShell>
+        <Text type="secondary">Loading…</Text>
+      </PanelShell>
+    );
+
+  const shownErrors = validationErrors.length ? validationErrors : liveErrors;
+
+  return (
+    <PanelShell>
+      {isDirty && (
+        <Alert
+          type="warning"
+          showIcon
+          message="Unsaved changes to webhook delivery"
+          description="Review the diff in the Apply dialog before persisting. Changes apply live — no restart."
+          action={
+            <Space>
+              <Button size="small" onClick={discard} disabled={applying}>
+                Discard
+              </Button>
+              <Button
+                type="primary"
+                size="small"
+                onClick={runApply}
+                disabled={applying}
+                loading={applying}
+              >
+                Apply
+              </Button>
+            </Space>
+          }
+        />
+      )}
+
+      {shownErrors.length > 0 && (
+        <Alert
+          type="error"
+          showIcon
+          message="Fix these before applying"
+          description={
+            <ul style={{ margin: 0, paddingLeft: 18 }}>
+              {shownErrors.map((e, i) => (
+                <li key={i}>{e}</li>
+              ))}
+            </ul>
+          }
+        />
+      )}
+
+      {/* Live delivery status strip */}
+      {outboxCounts && (
+        <Alert
+          type={outboxCounts.active ? 'success' : 'info'}
+          showIcon
+          message={
+            <Space size="middle" wrap>
+              <span>
+                Delivery:{' '}
+                <Tag color={outboxCounts.active ? 'green' : outboxCounts.enabled ? 'orange' : 'default'}>
+                  {outboxCounts.active ? 'Active' : outboxCounts.enabled ? 'Enabled (no endpoint)' : 'Disabled'}
+                </Tag>
+              </span>
+              <span>{outboxCounts.pending} pending</span>
+              <span>{outboxCounts.failed} failed</span>
+              <Button
+                type="link"
+                size="small"
+                style={{ padding: 0 }}
+                onClick={() => nav.navigate('admin/diagnostics/event-outbox')}
+              >
+                View event outbox →
+              </Button>
+            </Space>
+          }
+        />
+      )}
+
+      {/* Master switch + endpoints */}
+      <div style={cardStyle}>
+        <SectionHeader
+          icon={<SendOutlined />}
+          title="Webhook delivery"
+          description="Deliver durable object events (create/delete/copy) to HTTP endpoints. The outbox accrues events even while disabled — they deliver once you enable + add an endpoint."
+        />
+        <div style={{ marginTop: 16 }}>
+          <FormField label="Enable delivery" yamlPath="advanced.event_delivery.enabled">
+            <Switch checked={value.enabled} onChange={(v) => setField({ enabled: v })} />
+          </FormField>
+
+          <FormField
+            label="Endpoints"
+            yamlPath="advanced.event_delivery.webhook_urls"
+            helpText="HTTP(S) URLs that receive a deltaglider.event.v1 JSON payload. An event is marked delivered only after every endpoint returns 2xx."
+          >
+            <Space direction="vertical" style={{ width: '100%' }}>
+              {urlRows.length === 0 && (
+                <Text type="secondary" style={{ fontSize: 12 }}>
+                  No endpoints. Add one to start delivering.
+                </Text>
+              )}
+              {urlRows.map((row) => (
+                <Space.Compact key={row.id} style={{ width: '100%' }}>
+                  <Input
+                    value={row.url}
+                    onChange={(e) => updateUrl(row.id, e.target.value)}
+                    placeholder="https://hooks.example.com/deltaglider"
+                    style={{ ...inputRadius, fontFamily: 'var(--font-mono)', fontSize: 13 }}
+                  />
+                  <Button
+                    icon={<DeleteOutlined />}
+                    onClick={() => removeUrl(row.id)}
+                    title="Remove endpoint"
+                  />
+                </Space.Compact>
+              ))}
+              <Button icon={<PlusOutlined />} onClick={addUrl} size="small">
+                Add endpoint
+              </Button>
+            </Space>
+          </FormField>
+
+          <FormField
+            label="Headers"
+            yamlPath="advanced.event_delivery.webhook_headers"
+            helpText="Static headers sent with every request — e.g. an Authorization bearer token. Values are stored encrypted and shown masked; leave a masked value untouched to keep it."
+          >
+            <Space direction="vertical" style={{ width: '100%' }}>
+              {headerRows.length === 0 && (
+                <Text type="secondary" style={{ fontSize: 12 }}>
+                  No headers.
+                </Text>
+              )}
+              {headerRows.map((row) => (
+                <Space.Compact key={row.id} style={{ width: '100%' }}>
+                  <Input
+                    value={row.name}
+                    onChange={(e) => updateHeader(row.id, { name: e.target.value })}
+                    placeholder="Authorization"
+                    style={{ ...inputRadius, fontFamily: 'var(--font-mono)', fontSize: 13, width: '40%' }}
+                  />
+                  <Input
+                    value={row.masked ? '' : row.value}
+                    onChange={(e) => updateHeader(row.id, { value: e.target.value })}
+                    placeholder={row.masked ? '•••••••• (unchanged — type to replace)' : 'Bearer …'}
+                    style={{ ...inputRadius, fontFamily: 'var(--font-mono)', fontSize: 13 }}
+                  />
+                  <Button
+                    icon={<DeleteOutlined />}
+                    onClick={() => removeHeader(row.id)}
+                    title="Remove header"
+                  />
+                </Space.Compact>
+              ))}
+              <Button icon={<PlusOutlined />} onClick={addHeader} size="small">
+                Add header
+              </Button>
+            </Space>
+          </FormField>
+        </div>
+      </div>
+
+      {/* Advanced tuning */}
+      <div style={cardStyle}>
+        <AdvancedDisclosure title="Delivery tuning (retry, retention, batching)">
+          <DurationField
+            label="Tick interval"
+            yamlPath="advanced.event_delivery.tick_interval"
+            help="How often the dispatcher wakes to deliver due events."
+            value={value.tick_interval}
+            placeholder="10s"
+            onChange={(v) => setField({ tick_interval: v })}
+            inputRadius={inputRadius}
+          />
+          <NumberField
+            label="Batch size"
+            yamlPath="advanced.event_delivery.batch_size"
+            help="Max events claimed per tick (clamped 1–500)."
+            value={value.batch_size}
+            min={1}
+            max={500}
+            onChange={(v) => setField({ batch_size: v })}
+          />
+          <DurationField
+            label="Request timeout"
+            yamlPath="advanced.event_delivery.request_timeout"
+            help="Per-endpoint HTTP timeout."
+            value={value.request_timeout}
+            placeholder="5s"
+            onChange={(v) => setField({ request_timeout: v })}
+            inputRadius={inputRadius}
+          />
+          <NumberField
+            label="Max attempts"
+            yamlPath="advanced.event_delivery.max_attempts"
+            help="Attempts before an event becomes permanently failed."
+            value={value.max_attempts}
+            min={1}
+            onChange={(v) => setField({ max_attempts: v })}
+          />
+          <DurationField
+            label="Retry base"
+            yamlPath="advanced.event_delivery.retry_base"
+            help="Initial retry delay; exponential backoff doubles it per attempt."
+            value={value.retry_base}
+            placeholder="5s"
+            onChange={(v) => setField({ retry_base: v })}
+            inputRadius={inputRadius}
+          />
+          <DurationField
+            label="Retry max"
+            yamlPath="advanced.event_delivery.retry_max"
+            help="Ceiling for the backoff delay."
+            value={value.retry_max}
+            placeholder="5m"
+            onChange={(v) => setField({ retry_max: v })}
+            inputRadius={inputRadius}
+          />
+          <DurationField
+            label="Stale claim after"
+            yamlPath="advanced.event_delivery.stale_claim_after"
+            help="In-progress claims older than this are reclaimable (crash recovery)."
+            value={value.stale_claim_after}
+            placeholder="60s"
+            onChange={(v) => setField({ stale_claim_after: v })}
+            inputRadius={inputRadius}
+          />
+          <DurationField
+            label="Delivered retention"
+            yamlPath="advanced.event_delivery.delivered_retention"
+            help="Delivered rows older than this are pruned. 0s keeps them until manually pruned."
+            value={value.delivered_retention}
+            placeholder="24h"
+            onChange={(v) => setField({ delivered_retention: v })}
+            inputRadius={inputRadius}
+          />
+          <NumberField
+            label="Delivered max rows"
+            yamlPath="advanced.event_delivery.delivered_max_rows"
+            help="Cap on retained delivered rows (pending/failed never pruned by this)."
+            value={value.delivered_max_rows}
+            min={0}
+            onChange={(v) => setField({ delivered_max_rows: v })}
+          />
+          <NumberField
+            label="Prune batch"
+            yamlPath="advanced.event_delivery.prune_batch"
+            help="Max delivered rows pruned per tick."
+            value={value.prune_batch}
+            min={0}
+            onChange={(v) => setField({ prune_batch: v })}
+          />
+        </AdvancedDisclosure>
+      </div>
+
+      <ApplyDialog
+        open={applyOpen}
+        section="advanced"
+        response={applyResponse as SectionApplyResponse | null}
+        onApply={confirmApply}
+        onCancel={cancelApply}
+        loading={applying}
+      />
+    </PanelShell>
+  );
+}
+
+function DurationField(props: {
+  label: string;
+  yamlPath: string;
+  help: string;
+  value: string;
+  placeholder: string;
+  onChange: (v: string) => void;
+  inputRadius: React.CSSProperties;
+}) {
+  return (
+    <FormField
+      label={
+        <>
+          {props.label} <ApiOutlined style={{ opacity: 0 }} />
+        </>
+      }
+      yamlPath={props.yamlPath}
+      helpText={`${props.help} Format: 30s, 5m, 24h.`}
+    >
+      <Input
+        value={props.value}
+        onChange={(e) => props.onChange(e.target.value)}
+        placeholder={props.placeholder}
+        style={{ ...props.inputRadius, fontFamily: 'var(--font-mono)', fontSize: 13, maxWidth: 160 }}
+      />
+    </FormField>
+  );
+}
+
+function NumberField(props: {
+  label: string;
+  yamlPath: string;
+  help: string;
+  value: number;
+  min: number;
+  max?: number;
+  onChange: (v: number) => void;
+}) {
+  return (
+    <FormField label={props.label} yamlPath={props.yamlPath} helpText={props.help}>
+      <InputNumber
+        value={props.value}
+        min={props.min}
+        max={props.max}
+        onChange={(v) => props.onChange(typeof v === 'number' ? v : props.min)}
+        style={{ maxWidth: 160 }}
+      />
+    </FormField>
+  );
+}

--- a/demo/s3-browser/ui/src/components/adminNavigation.tsx
+++ b/demo/s3-browser/ui/src/components/adminNavigation.tsx
@@ -15,6 +15,7 @@ import {
   SettingOutlined,
   ThunderboltOutlined,
   SyncOutlined,
+  SendOutlined,
 } from '@ant-design/icons';
 import type { ReactNode } from 'react';
 import type { SectionName } from '../adminApi';
@@ -263,6 +264,15 @@ export const ADMIN_IA: Array<{ group: string; entries: SidebarEntry[] }> = [
             dirtyKey: 'configuration/advanced/sync',
             description:
               'S3 bucket for encrypted IAM/config database HA across proxy instances. This is not object replication.',
+          },
+          {
+            path: 'configuration/advanced/event-delivery',
+            label: 'Webhook delivery',
+            icon: <SendOutlined />,
+            section: 'advanced',
+            dirtyKey: 'configuration/advanced/event-delivery',
+            description:
+              'Deliver durable object events to HTTP webhooks: endpoints, auth headers, retry backoff, retention. Applies live, no restart.',
           },
         ],
       },

--- a/demo/s3-browser/ui/src/components/webhookDeliveryPayload.ts
+++ b/demo/s3-browser/ui/src/components/webhookDeliveryPayload.ts
@@ -25,9 +25,9 @@
  *    and clear `webhook_url` (→ explicit `null`) so the two never drift.
  */
 
-export const WEBHOOK_REDACTED_SENTINEL = '__redacted__';
+const WEBHOOK_REDACTED_SENTINEL = '__redacted__';
 
-export interface EventDeliveryConfig {
+interface EventDeliveryConfig {
   enabled: boolean;
   webhook_urls: string[];
   webhook_headers: Record<string, string>;
@@ -44,7 +44,7 @@ export interface EventDeliveryConfig {
 }
 
 /** Defaults mirror `EventDeliveryConfig::default` in src/config_sections.rs. */
-export const DEFAULT_EVENT_DELIVERY: EventDeliveryConfig = {
+const DEFAULT_EVENT_DELIVERY: EventDeliveryConfig = {
   enabled: false,
   webhook_urls: [],
   webhook_headers: {},
@@ -87,7 +87,7 @@ export interface AdvancedSectionWebhookBody {
  * fill defaults for absent fields and FOLD a legacy single `webhook_url`
  * into the `webhook_urls` list (deduped, legacy first).
  */
-export function normalizeEventDelivery(
+function normalizeEventDelivery(
   raw: EventDeliveryWire | undefined
 ): EventDeliveryConfig {
   const d = DEFAULT_EVENT_DELIVERY;
@@ -117,7 +117,12 @@ export function normalizeEventDelivery(
   };
 }
 
-const DURATION_RE = /^\s*\d+\s*(ns|us|µs|ms|s|m|h|d)\s*$/;
+// Compound humantime: one-or-more `<number><unit>` chunks, matching what the
+// Rust backend's `humantime::parse_duration` accepts (e.g. `30s`, `5m`, `24h`,
+// `1h30m`, `1500ms`). Units cover ns…weeks + common word forms. Kept in sync
+// with `humantime` on the Rust side (`src/config_sections.rs::validate_event_delivery`).
+const DURATION_RE =
+  /^\s*(\d+\s*(ns|us|µs|ms|sec|secs|s|min|mins|m|hr|hrs|h|day|days|d|week|weeks|w)\s*)+$/i;
 // http(s) URL with a host. Keep it permissive but reject obvious junk.
 const URL_RE = /^https?:\/\/[^\s/$.?#].[^\s]*$/i;
 // RFC 7230 token chars for header names.
@@ -137,7 +142,7 @@ interface ValidationResult {
  * `baseline` is needed to compute header DELETES (keys present at load but
  * removed now → emit `null`).
  */
-export function buildEventDeliveryPayload(
+function buildEventDeliveryPayload(
   local: EventDeliveryConfig,
   baseline: EventDeliveryConfig
 ): ValidationResult {
@@ -223,4 +228,142 @@ export function buildEventDeliveryPayload(
   };
 
   return { ok: true, errors: [], body };
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Form state — the SINGLE source of truth for the panel.
+//
+// The panel edits this shape directly as its `useSectionEditor` value (no
+// parallel mirror), so discard/refresh stay correct for free. Rows carry a
+// stable `id` (for React keys) and, for headers, the `origName` + `masked`
+// flags needed to render and validate the secret-mask UX. `formFromWire` is
+// the editor `pick`; `buildPayloadFromForm` is the validated `toPayload`.
+// ─────────────────────────────────────────────────────────────────────────
+
+export interface WebhookUrlRow {
+  id: string;
+  url: string;
+}
+
+export interface WebhookHeaderRow {
+  id: string;
+  name: string;
+  /** Current value. Equals the sentinel while an untouched secret is masked. */
+  value: string;
+  /** The header name as loaded from the server (empty for a freshly-added
+   *  row). Used to detect a rename-while-masked, which would lose the secret. */
+  origName: string;
+  /** True while `value` is still the server sentinel (untouched secret). */
+  masked: boolean;
+}
+
+export interface WebhookFormState {
+  enabled: boolean;
+  urlRows: WebhookUrlRow[];
+  headerRows: WebhookHeaderRow[];
+  /** Header names present when the form was loaded. Lets `buildPayloadFromForm`
+   *  emit RFC 7396 `null` deletes for headers the operator REMOVED (a removed
+   *  row is gone from `headerRows`, so its key must be remembered here). Not an
+   *  editable field — set once by `formFromWire`, carried through edits. */
+  loadedHeaderNames: string[];
+  tick_interval: string;
+  batch_size: number;
+  request_timeout: string;
+  max_attempts: number;
+  retry_base: string;
+  retry_max: string;
+  stale_claim_after: string;
+  delivered_retention: string;
+  delivered_max_rows: number;
+  prune_batch: number;
+}
+
+// Deterministic id generator INJECTED by the caller so this module stays pure
+// (no Math.random / crypto here — the panel passes a per-instance counter).
+type IdGen = () => string;
+
+/** Build the editor form state from a server wire body. */
+export function formFromWire(
+  raw: EventDeliveryWire | undefined,
+  nextId: IdGen
+): WebhookFormState {
+  const cfg = normalizeEventDelivery(raw);
+  return {
+    enabled: cfg.enabled,
+    urlRows: cfg.webhook_urls.map((url) => ({ id: nextId(), url })),
+    headerRows: Object.entries(cfg.webhook_headers).map(([name, value]) => ({
+      id: nextId(),
+      name,
+      value,
+      origName: name,
+      masked: value === WEBHOOK_REDACTED_SENTINEL,
+    })),
+    loadedHeaderNames: Object.keys(cfg.webhook_headers),
+    tick_interval: cfg.tick_interval,
+    batch_size: cfg.batch_size,
+    request_timeout: cfg.request_timeout,
+    max_attempts: cfg.max_attempts,
+    retry_base: cfg.retry_base,
+    retry_max: cfg.retry_max,
+    stale_claim_after: cfg.stale_claim_after,
+    delivered_retention: cfg.delivered_retention,
+    delivered_max_rows: cfg.delivered_max_rows,
+    prune_batch: cfg.prune_batch,
+  };
+}
+
+/** Flatten form rows back into the validated `EventDeliveryConfig` shape that
+ *  `buildEventDeliveryPayload` consumes. Empty (in-progress) rows are dropped;
+ *  the baseline is reconstructed from each header's `origName` so removals
+ *  produce the right RFC 7396 `null` deletes. */
+export function buildPayloadFromForm(form: WebhookFormState): ValidationResult {
+  const errors: string[] = [];
+
+  // Rename-while-masked guard (adversarial #2): a masked secret has no value to
+  // carry under a NEW key, so the server would drop it. Force re-entry.
+  for (const h of form.headerRows) {
+    const name = h.name.trim();
+    if (h.masked && name && h.origName && name !== h.origName) {
+      errors.push(
+        `Header "${h.origName}" was renamed to "${name}" without re-entering its value. Re-type the value (it's masked for security) or remove and re-add the header.`
+      );
+    }
+  }
+
+  const local: EventDeliveryConfig = {
+    enabled: form.enabled,
+    webhook_urls: form.urlRows.map((r) => r.url),
+    webhook_headers: {},
+    tick_interval: form.tick_interval,
+    batch_size: form.batch_size,
+    request_timeout: form.request_timeout,
+    max_attempts: form.max_attempts,
+    retry_base: form.retry_base,
+    retry_max: form.retry_max,
+    stale_claim_after: form.stale_claim_after,
+    delivered_retention: form.delivered_retention,
+    delivered_max_rows: form.delivered_max_rows,
+    prune_batch: form.prune_batch,
+  };
+  for (const h of form.headerRows) {
+    const name = h.name.trim();
+    if (name) local.webhook_headers[name] = h.value;
+  }
+
+  // Baseline = the header names present at LOAD time, so headers the operator
+  // removed (gone from `headerRows`) still produce an RFC 7396 `null` delete.
+  // We only need the KEYS, so any value works.
+  const baseline: EventDeliveryConfig = {
+    ...local,
+    webhook_headers: {},
+  };
+  for (const name of form.loadedHeaderNames) {
+    baseline.webhook_headers[name] = WEBHOOK_REDACTED_SENTINEL;
+  }
+
+  const res = buildEventDeliveryPayload(local, baseline);
+  if (errors.length > 0) {
+    return { ok: false, errors: [...errors, ...res.errors] };
+  }
+  return res;
 }

--- a/demo/s3-browser/ui/src/components/webhookDeliveryPayload.ts
+++ b/demo/s3-browser/ui/src/components/webhookDeliveryPayload.ts
@@ -1,0 +1,226 @@
+/**
+ * Pure payload + validation helpers for the Webhook delivery panel
+ * (`event_delivery`). No React / antd imports so the Node regression
+ * script can transpile-and-import it directly.
+ *
+ * ## The two correctness hazards this module owns
+ *
+ * 1. **Header-delete null.** The server applies RFC 7396 merge-patch to
+ *    `webhook_headers`: an absent key is PRESERVED, only an explicit JSON
+ *    `null` deletes it. So removing a header in the UI must emit
+ *    `{ "<removed-key>": null }` — diffing the edited map against the
+ *    BASELINE map. Without this, "delete header" is silently a no-op.
+ *
+ * 2. **Secret round-trip.** The server masks each header VALUE to
+ *    `WEBHOOK_REDACTED_SENTINEL` on GET (keeping the key). A value left as
+ *    the sentinel means "unchanged" — we pass it through and the server
+ *    restores the real token. A retyped value overwrites. The UI must
+ *    never let the operator save the literal sentinel as a real value, and
+ *    must never display a real token (it only ever sees the sentinel).
+ *
+ * 3. **Legacy `webhook_url`.** The backend has both `webhook_url`
+ *    (singleton) and `webhook_urls` (list). The UI surfaces ONE endpoint
+ *    list bound to `webhook_urls`; on load we fold any legacy single
+ *    `webhook_url` into the list, and on save we always write `webhook_urls`
+ *    and clear `webhook_url` (→ explicit `null`) so the two never drift.
+ */
+
+export const WEBHOOK_REDACTED_SENTINEL = '__redacted__';
+
+export interface EventDeliveryConfig {
+  enabled: boolean;
+  webhook_urls: string[];
+  webhook_headers: Record<string, string>;
+  tick_interval: string;
+  batch_size: number;
+  request_timeout: string;
+  max_attempts: number;
+  retry_base: string;
+  retry_max: string;
+  stale_claim_after: string;
+  delivered_retention: string;
+  delivered_max_rows: number;
+  prune_batch: number;
+}
+
+/** Defaults mirror `EventDeliveryConfig::default` in src/config_sections.rs. */
+export const DEFAULT_EVENT_DELIVERY: EventDeliveryConfig = {
+  enabled: false,
+  webhook_urls: [],
+  webhook_headers: {},
+  tick_interval: '10s',
+  batch_size: 50,
+  request_timeout: '5s',
+  max_attempts: 8,
+  retry_base: '5s',
+  retry_max: '5m',
+  stale_claim_after: '60s',
+  delivered_retention: '24h',
+  delivered_max_rows: 10000,
+  prune_batch: 100,
+};
+
+/** The wire shape of `event_delivery` as the server GET returns it. */
+export interface EventDeliveryWire {
+  enabled?: boolean;
+  webhook_url?: string | null;
+  webhook_urls?: string[];
+  webhook_headers?: Record<string, string>;
+  tick_interval?: string;
+  batch_size?: number;
+  request_timeout?: string;
+  max_attempts?: number;
+  retry_base?: string;
+  retry_max?: string;
+  stale_claim_after?: string;
+  delivered_retention?: string;
+  delivered_max_rows?: number;
+  prune_batch?: number;
+}
+
+export interface AdvancedSectionWebhookBody {
+  event_delivery?: EventDeliveryWire;
+}
+
+/**
+ * Normalize a server `event_delivery` body to the local editing shape:
+ * fill defaults for absent fields and FOLD a legacy single `webhook_url`
+ * into the `webhook_urls` list (deduped, legacy first).
+ */
+export function normalizeEventDelivery(
+  raw: EventDeliveryWire | undefined
+): EventDeliveryConfig {
+  const d = DEFAULT_EVENT_DELIVERY;
+  const ed = raw ?? {};
+  const urls: string[] = [];
+  if (typeof ed.webhook_url === 'string' && ed.webhook_url.trim()) {
+    urls.push(ed.webhook_url.trim());
+  }
+  for (const u of ed.webhook_urls ?? []) {
+    const t = (u ?? '').trim();
+    if (t && !urls.includes(t)) urls.push(t);
+  }
+  return {
+    enabled: ed.enabled ?? d.enabled,
+    webhook_urls: urls,
+    webhook_headers: { ...(ed.webhook_headers ?? {}) },
+    tick_interval: ed.tick_interval ?? d.tick_interval,
+    batch_size: ed.batch_size ?? d.batch_size,
+    request_timeout: ed.request_timeout ?? d.request_timeout,
+    max_attempts: ed.max_attempts ?? d.max_attempts,
+    retry_base: ed.retry_base ?? d.retry_base,
+    retry_max: ed.retry_max ?? d.retry_max,
+    stale_claim_after: ed.stale_claim_after ?? d.stale_claim_after,
+    delivered_retention: ed.delivered_retention ?? d.delivered_retention,
+    delivered_max_rows: ed.delivered_max_rows ?? d.delivered_max_rows,
+    prune_batch: ed.prune_batch ?? d.prune_batch,
+  };
+}
+
+const DURATION_RE = /^\s*\d+\s*(ns|us|µs|ms|s|m|h|d)\s*$/;
+// http(s) URL with a host. Keep it permissive but reject obvious junk.
+const URL_RE = /^https?:\/\/[^\s/$.?#].[^\s]*$/i;
+// RFC 7230 token chars for header names.
+const HEADER_NAME_RE = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
+
+interface ValidationResult {
+  ok: boolean;
+  errors: string[];
+  /** Wire body for the section PUT, only present when ok. */
+  body?: AdvancedSectionWebhookBody;
+}
+
+/**
+ * Validate the edited config against the BASELINE (the normalized
+ * server-loaded value) and produce the section-PUT body.
+ *
+ * `baseline` is needed to compute header DELETES (keys present at load but
+ * removed now → emit `null`).
+ */
+export function buildEventDeliveryPayload(
+  local: EventDeliveryConfig,
+  baseline: EventDeliveryConfig
+): ValidationResult {
+  const errors: string[] = [];
+
+  const urls = local.webhook_urls.map((u) => u.trim()).filter((u) => u.length > 0);
+  for (const u of urls) {
+    if (!URL_RE.test(u)) errors.push(`Endpoint "${u}" is not a valid http(s) URL.`);
+  }
+  // Usability invariant: enabling delivery with no endpoint is a no-op trap.
+  if (local.enabled && urls.length === 0) {
+    errors.push('Delivery is enabled but no endpoint is set — add at least one webhook URL or turn delivery off.');
+  }
+
+  // Header validation + secret-sentinel guard.
+  for (const [name, value] of Object.entries(local.webhook_headers)) {
+    if (!HEADER_NAME_RE.test(name)) {
+      errors.push(`Header name "${name}" contains invalid characters.`);
+    }
+    if (value === '') {
+      errors.push(`Header "${name}" has an empty value.`);
+    }
+  }
+
+  const durations: Array<[string, string]> = [
+    ['tick_interval', local.tick_interval],
+    ['request_timeout', local.request_timeout],
+    ['retry_base', local.retry_base],
+    ['retry_max', local.retry_max],
+    ['stale_claim_after', local.stale_claim_after],
+    ['delivered_retention', local.delivered_retention],
+  ];
+  for (const [field, v] of durations) {
+    // delivered_retention accepts "0s" to disable pruning; all parse via the RE.
+    if (!DURATION_RE.test(v)) {
+      errors.push(`${field} "${v}" is not a duration like 30s, 5m, or 24h.`);
+    }
+  }
+
+  const numbers: Array<[string, number, number]> = [
+    ['batch_size', local.batch_size, 1],
+    ['max_attempts', local.max_attempts, 1],
+    ['delivered_max_rows', local.delivered_max_rows, 0],
+    ['prune_batch', local.prune_batch, 0],
+  ];
+  for (const [field, v, min] of numbers) {
+    if (!Number.isFinite(v) || !Number.isInteger(v) || v < min) {
+      errors.push(`${field} must be an integer ≥ ${min}.`);
+    }
+  }
+
+  if (errors.length > 0) return { ok: false, errors };
+
+  // Build webhook_headers patch: current values + explicit null for removed keys.
+  const headerPatch: Record<string, string | null> = {};
+  for (const [k, v] of Object.entries(local.webhook_headers)) {
+    headerPatch[k] = v; // may be the sentinel (= "unchanged", server restores)
+  }
+  for (const k of Object.keys(baseline.webhook_headers)) {
+    if (!(k in local.webhook_headers)) {
+      headerPatch[k] = null; // RFC 7396 delete
+    }
+  }
+
+  const body: AdvancedSectionWebhookBody = {
+    event_delivery: {
+      enabled: local.enabled,
+      // Always write webhook_urls; clear the legacy singleton so they can't drift.
+      webhook_url: null,
+      webhook_urls: urls,
+      webhook_headers: headerPatch as Record<string, string>,
+      tick_interval: local.tick_interval.trim(),
+      batch_size: local.batch_size,
+      request_timeout: local.request_timeout.trim(),
+      max_attempts: local.max_attempts,
+      retry_base: local.retry_base.trim(),
+      retry_max: local.retry_max.trim(),
+      stale_claim_after: local.stale_claim_after.trim(),
+      delivered_retention: local.delivered_retention.trim(),
+      delivered_max_rows: local.delivered_max_rows,
+      prune_batch: local.prune_batch,
+    },
+  };
+
+  return { ok: true, errors: [], body };
+}

--- a/docs/dev/ci-infra.md
+++ b/docs/dev/ci-infra.md
@@ -106,6 +106,49 @@ Key configuration:
 **Why per-pod PVCs matter for Rust:**
 Rust compilation creates thousands of intermediate files (`.o`, `.rlib`, `.rmeta`) in the `target/` directory. With overlay2 (the default for emptyDir in container jobs), every write triggers a copy-on-write operation. On a project with ~80 crates, this added minutes to compilation. Direct SSD access via PVC bypasses this entirely.
 
+**Open-file limit (`nofile`) — REQUIRED, both host and workflow:**
+The runners execute inside **Ryzen LXC containers** (the `k3s` label is a historical
+alias — there is no Kubernetes anymore). An LXC container inherits a **low default
+`nofile` (~1024)** unless raised. The integration job runs **~35 test binaries in one
+`cargo test` invocation**, each spawning its own proxy + MinIO sockets, so the *aggregate*
+open-fd count easily crosses 1024 and surfaces — non-deterministically, under load — as:
+
+```
+ConnectError("tcp open error", Os { code: 24, message: "Too many open files" })
+```
+
+It typically panics mid-seed in whichever test opens the most connections (historically
+`recursive_delete_test`, which seeds 1100 objects), but the root cause is the shared,
+under-sized fd table, not any single test. Two layers fix it (keep BOTH):
+
+1. **Host side (the real fix).** On the Ryzen host, raise the LXC container's limit so
+   everything inside inherits it. Run the idempotent helper as root on the host:
+   ```
+   sudo scripts/bump-runner-nofile.sh            # auto-detects LXC/Incus/LXD containers
+   sudo scripts/bump-runner-nofile.sh ct1 ct2    # or name them explicitly
+   ```
+   It sets `lxc.prlimit.nofile` (or the Incus/LXD `limits.kernel.nofile` equivalent) and
+   pins `LimitNOFILE` on the in-container `actions-runner` systemd unit. Equivalent manual
+   steps:
+   ```
+   # /var/lib/lxc/<container>/config
+   lxc.prlimit.nofile = 1048576
+   # systemctl edit actions-runner   →   [Service]
+   LimitNOFILE=1048576
+   ```
+   Restart the container afterwards (`lxc-stop && lxc-start`, or `incus restart`). Verify
+   from a job step: `ulimit -Sn; ulimit -Hn; cat /proc/sys/fs/file-max`.
+
+2. **Workflow side (belt-and-suspenders, self-documenting).** Every `container:` block in
+   `ci.yml` sets `options: --ulimit nofile=1048576:1048576`. This makes the requirement
+   visible to future readers and keeps the workflow portable to a fresh runner host that
+   hasn't had the host-side bump applied yet. (It only takes effect up to the host's hard
+   limit, so the host bump in #1 is still authoritative.)
+
+Tests should also avoid unbounded N-way connection fan-out (cap seeding with a
+`tokio::sync::Semaphore`) so a single test can't dominate the shared fd budget — but that
+is hygiene, not a substitute for the limit bump.
+
 ### 3. sccache + Local MinIO
 
 **Manifest:** `.github/k8s/sccache-minio.yaml`

--- a/docs/plan/webhook-gui-impl.md
+++ b/docs/plan/webhook-gui-impl.md
@@ -1,0 +1,121 @@
+# Webhook GUI — implementation checklist (execution)
+
+Scope locked with user: **config panel only** (no test-ping route). Header values
+treated as secrets with **preserve-on-untouched** UX. "Usability bugs ARE bugs."
+
+## Backend (Rust)
+
+### B1. Redact webhook header values + credential-bearing URL on GET
+`src/config.rs::redact_all_secrets` (~2007). Header VALUES can carry bearer tokens
+→ redact them to a sentinel so the GUI shows masked, and the operator never sees
+the real token. Decision: use an explicit **string sentinel** `"__redacted__"`
+(NOT `None`-omit, because the map needs to keep its KEYS so the UI can show which
+headers exist while masking values).
+- Add: for `export.event_delivery.webhook_headers`, replace every value with
+  `REDACTED_SENTINEL`. Keep keys.
+- `webhook_url` / `webhook_urls`: endpoints are not secrets per se, but may embed
+  `https://user:tok@host`. Leave URLs visible (operators need to see/verify the
+  endpoint); document that credentials belong in headers, not the URL. (No redaction
+  on URLs — keeps the editor honest.)
+- Define `pub const REDACTED_SENTINEL: &str = "__redacted__";` somewhere shared
+  (config.rs) so the preserve helper + tests reference one constant.
+
+### B2. Preserve unredacted header values on PUT
+`src/api/admin/config/section_level.rs::apply_section` preserve block (~305-406),
++ a helper in `config/mod.rs` next to `preserve_sigv4_pair`.
+- New `pub(super) fn preserve_event_delivery_secrets(new: &mut EventDeliveryConfig,
+  old: &EventDeliveryConfig)`: for each header in `new.webhook_headers`, if value ==
+  `REDACTED_SENTINEL`, replace with `old.webhook_headers.get(key)` (drop the entry if
+  the old map lacks it — a redacted value for a brand-new key is nonsense, treat as
+  "unset"). Headers the operator actually retyped (value != sentinel) pass through.
+  Headers the operator REMOVED are simply absent from `new` (merge-patch handled it).
+- Call it in the preserve block alongside the sigv4 calls.
+
+### B3. Merge-patch foot-gun: header DELETE must produce explicit nulls
+The RFC 7396 merge applies key-by-key; an absent key is PRESERVED, only an explicit
+`null` deletes. The FRONTEND `toPayload` must therefore diff against the loaded
+baseline and emit `null` for removed header keys. (Backend already supports it —
+this is a frontend obligation, see F4.) Add a backend test proving
+`{"webhook_headers":{"X":null}}` deletes X.
+
+### B4. Tests (Rust)
+- Unit/integration in `admin_section_test.rs`: (a) GET redacts header values to
+  sentinel, keeps keys; (b) PUT with sentinel value preserves old token; (c) PUT
+  with a real new value overwrites; (d) PUT with `null` value deletes the header;
+  (e) full round-trip GET→unchanged PUT leaves tokens intact.
+- Pure-fn unit test for `preserve_event_delivery_secrets` truth table (no server).
+
+## Frontend (React/TS)
+
+### F1. Types
+`adminApi.ts` (or s3client/adminApi): `EventDeliveryConfig` interface (13 fields),
+`DEFAULT_EVENT_DELIVERY` matching Rust defaults, `AdvancedSectionBody` gains
+`event_delivery?: EventDeliveryConfig`. Export `WEBHOOK_REDACTED_SENTINEL = "__redacted__"`.
+
+### F2. Panel `WebhookDeliveryPanel.tsx`
+Mirror `ReplicationPanel`. `useSectionEditor<AdvancedSectionBody, EventDeliveryConfig>`
+with `section:'advanced'`, `dirtyKey:'configuration/advanced/event-delivery'`,
+`pick: b => b.event_delivery ?? DEFAULT`, `toPayload` = F4.
+UI:
+- **Master switch** `enabled`. When off, show an info note that delivery is paused
+  (and the outbox still accrues events — they deliver when re-enabled).
+- **Endpoints list** — ONE list editing `webhook_urls` (map a legacy single
+  `webhook_url` into the list on load, clear it on save → write only `webhook_urls`).
+  Add/remove rows with STABLE ids (not array-index keys — admin-editor bug class).
+  Validate each is a parseable http(s) URL; inline error per row.
+- **Headers** — key/value rows. Value field renders a **masked placeholder** when the
+  loaded value is the sentinel ("•••••• (unchanged)"); typing replaces it. A clear
+  "edit" affordance to overwrite. Remove-row deletes the header (→ null in payload).
+  Validate header NAME (token chars) + non-empty.
+- **Advanced disclosure** (collapsed): tick_interval, batch_size, request_timeout,
+  max_attempts, retry_base, retry_max, stale_claim_after, delivered_retention,
+  delivered_max_rows, prune_batch. Each `Field` with YAML-path breadcrumb + default
+  placeholder. Validate humantime durations + numeric ranges client-side (mirror
+  `validate_event_delivery`) with inline errors.
+- **Live delivery strip** (top): fetch `GET /_/api/admin/event-outbox?limit=1` →
+  show `delivery_enabled`/`delivery_active` + pending/failed counts + link to
+  `diagnostics/event-outbox`. Read-only.
+- **Apply flow**: guarded validation → ApplyDialog → PUT → markApplied; register
+  `useApplyHandler` for ⌘S. Discard restores.
+
+### F3. Nav + routing
+- `adminNavigation.tsx`: add entry after `sync` (line ~266): path
+  `configuration/advanced/event-delivery`, label "Webhook delivery", icon
+  `<SendOutlined/>`, section 'advanced', dirtyKey matching.
+- `AdminPage.tsx`: import `WebhookDeliveryPanel`; add branch after the `sync` block
+  (~730): `if (adminPath === 'configuration/advanced/event-delivery') {...}`.
+
+### F4. `webhookDeliveryPayload.ts` (pure, Node-testable)
+- `normalizeEventDelivery(raw): EventDeliveryConfig` — fill defaults, fold legacy
+  `webhook_url` into `webhook_urls`.
+- `buildEventDeliveryPayload(local, baseline): { ok, body|errors }` — validates
+  (URLs, header names, durations, ranges); produces the wire `{ event_delivery: {...} }`
+  including:
+  - `webhook_urls` always written (legacy `webhook_url` set to `null` to clear it).
+  - `webhook_headers`: for each CURRENT header → value (or sentinel passthrough means
+    "unchanged" → we send sentinel and backend preserves); for each header in BASELINE
+    but REMOVED in current → emit `null` (RFC 7396 delete). THIS is the foot-gun fix.
+  - empty headers → send `{}` only if baseline had headers (to clear); else omit.
+- Node regression test `webhookDeliveryPayload.test.mjs` covering: removed-header→null,
+  unchanged-secret→sentinel, new-secret→value, legacy url fold, duration validation,
+  clear-all-headers. (admin-editor bug-class pattern.)
+
+### F5. Usability bugs to NOT ship (the "usability bugs ARE bugs" mandate)
+1. Masked header value must be distinguishable from a real value `"••••"` — never let
+   the operator accidentally PUT the literal mask string.
+2. Removing then re-adding a header with the same name must work (stable-id rows).
+3. Enabling delivery with zero endpoints must be blocked with a clear message
+   (`is_active` needs ≥1 endpoint) — don't let them save a no-op "enabled" state.
+4. Duration fields: accept `30s`/`5m`/`24h`; reject `30`/`5 minutes` with a hint.
+5. Dirty-dot + ⌘S + beforeunload must work (via useSectionEditor/useApplyHandler).
+6. Discard must restore masked placeholders, not clear them.
+7. Apply summary/diff must NOT leak the real token (show sentinel/masked in the diff).
+
+## Gate
+- `cargo build && cargo clippy -D warnings && cargo test --lib` + the new section tests.
+- `cd demo/s3-browser/ui && npm run build && npm run lint && tsc --noEmit && npx knip`
+  + `node webhookDeliveryPayload.test.mjs`.
+- `cargo run -- config schema` regenerates clean (no new fields, but verify).
+- Local: restart-with-prod-backup, open `/_/admin/configuration/advanced/event-delivery`,
+  exercise enable + endpoint + header(secret) + advanced + apply + reload round-trip,
+  confirm token not leaked and preserved.

--- a/docs/plan/webhook-gui.md
+++ b/docs/plan/webhook-gui.md
@@ -1,0 +1,167 @@
+# Webhook GUI — make event-delivery config GUI-editable
+
+## Context
+
+Event-delivery (the webhook side of the durable `event_outbox`) is the one config
+surface that is still **YAML/env-only**: there is no admin GUI to edit it. Operators
+can already *observe* delivery via the **Event outbox** diagnostics panel
+(`diagnostics/event-outbox` → `EventOutboxPanel`, backed by
+`GET /_/api/admin/event-outbox`), but to turn webhooks on, point them at an endpoint,
+add an auth header, or tune retry/retention they must hand-edit YAML and reload.
+
+This plan adds a **Configuration → Advanced → Webhook delivery** panel that edits
+`EventDeliveryConfig` through the exact same section-editor pipeline every other config
+panel uses. It is the natural companion to the just-shipped event-driven replication:
+both are independent listeners on the same outbox.
+
+**Scope:** edit the existing `EventDeliveryConfig` (no new backend config shape). The
+backend route, validation, schema, and hot-reload already exist — this is ~95% a
+frontend panel + nav wiring, plus a small "test delivery" affordance.
+
+## What already exists (verified, do NOT rebuild)
+
+- **Config struct** `EventDeliveryConfig` — `src/config_sections.rs:604-666`, nested at
+  `AdvancedSection.event_delivery` (`:1029-1034`). 13 fields:
+  `enabled: bool`, `webhook_url: Option<String>`, `webhook_urls: Vec<String>`,
+  `webhook_headers: BTreeMap<String,String>`, `tick_interval`, `batch_size`,
+  `request_timeout`, `max_attempts`, `retry_base`, `retry_max`, `stale_claim_after`,
+  `delivered_retention`, `delivered_max_rows`, `prune_batch`. Already `#[derive(JsonSchema)]`.
+- **Defaults** — `src/config_sections.rs:705-743` (enabled=false, tick=10s, batch=50,
+  timeout=5s, max_attempts=8, retry_base=5s, retry_max=5m, stale_claim=60s,
+  retention=24h, delivered_max_rows=10_000, prune_batch=100).
+- **Validation** — `validate_event_delivery()` `src/config_sections.rs:1567-1652`
+  (URL parse, header name/value, humantime durations, numeric ranges). Runs inside
+  `Config::check()` on every section apply. Nothing to add.
+- **Gating accessors** — `is_active()` (`enabled && !endpoints.is_empty()`),
+  `webhook_endpoints()` (merges `webhook_url` + `webhook_urls`, trims, drops empties)
+  — `src/config_sections.rs:668-681`.
+- **Backend section route** — `PUT /api/admin/config/section/advanced` (RFC 7396
+  merge-patch), `GET .../advanced`, `POST .../advanced/validate` (dry-run) —
+  `src/api/admin/config/section_level.rs:132-630`. Hot-reloads: the dispatcher
+  re-reads `SharedConfig` every tick (`src/event_delivery.rs:122-129`), so changes
+  apply with **no restart**.
+- **Outbox viewer** — `GET /_/api/admin/event-outbox` returns rows + status counts +
+  `delivery_enabled` / `delivery_active`; `POST .../:id/requeue` and bulk requeue —
+  `src/api/admin/event_outbox.rs:50-193`. Frontend `EventOutboxPanel.tsx` at
+  `diagnostics/event-outbox`.
+- **JSON Schema** — auto-generated via `schemars::schema_for!(Config)`
+  (`src/cli/config.rs:92-107`); CI "Config JSON Schema" job regenerates it. No new
+  fields here → schema is already correct.
+
+## Frontend pattern to mirror (exact anchors)
+
+- **`useSectionEditor<Wire, Local>`** — `demo/s3-browser/ui/src/useSectionEditor.ts:115-247`.
+  The single home for fetch → dirty → validate → ApplyDialog → PUT → markApplied. Use
+  `section: 'advanced'`, `pick: (body) => body.event_delivery`,
+  `toPayload: (v) => ({ event_delivery: v })`.
+- **Exemplar panel** — `ReplicationPanel.tsx:1-425` (best match: edits a nested
+  advanced/storage struct with arrays, has Advanced disclosure for optional fields,
+  guarded apply, `useApplyHandler` for ⌘S, ApplyDialog wiring). Copy its skeleton.
+  `LoggingPanel.tsx` is the *minimal* exemplar (single nested field) if a leaner start
+  is wanted.
+- **Nav entry** — add to `ADMIN_IA` advanced children array, after the `sync` entry at
+  `adminNavigation.tsx:266`. Shape (matches siblings exactly):
+  ```tsx
+  {
+    path: 'configuration/advanced/event-delivery',
+    label: 'Webhook delivery',
+    icon: <SendOutlined />,            // import from @ant-design/icons
+    section: 'advanced',
+    dirtyKey: 'configuration/advanced/event-delivery',
+    description:
+      'Durable event webhook delivery: endpoints, auth headers, retry backoff, retention. Applies live, no restart.',
+  },
+  ```
+- **AdminPage routing** — add a branch alongside the other advanced ones at
+  `AdminPage.tsx:730` (after the `sync` block):
+  ```tsx
+  if (adminPath === 'configuration/advanced/event-delivery') {
+    return (<>{header}<WebhookDeliveryPanel onSessionExpired={onSessionExpired} /></>);
+  }
+  ```
+  Import `WebhookDeliveryPanel` near the other panel imports (`AdminPage.tsx:21-27`).
+  `LEGACY_TO_NEW` (`AdminPage.tsx:90-92`) needs **no** entry (this is a brand-new page,
+  no legacy flat URL to alias).
+
+## Implementation
+
+### Phase 1 — Frontend types + panel (the bulk)
+1. **Wire types** in `s3client.ts` (or wherever section bodies are typed): an
+   `EventDeliveryConfig` TS interface mirroring the 13 fields + a `DEFAULT_EVENT_DELIVERY`
+   const matching the Rust defaults. Add `event_delivery` to the `AdvancedSectionBody`
+   type used by the advanced-section editors.
+2. **`WebhookDeliveryPanel.tsx`** (new), copying `ReplicationPanel`'s skeleton:
+   - `useSectionEditor<AdvancedSectionBody, EventDeliveryConfig>({ section:'advanced',
+     dirtyKey:'configuration/advanced/event-delivery', initial: DEFAULT_EVENT_DELIVERY,
+     pick: b => b.event_delivery ?? DEFAULT_EVENT_DELIVERY,
+     toPayload: v => ({ event_delivery: v }), noun:'webhook delivery', onSessionExpired })`.
+   - **Primary fields**: `enabled` (Switch), `webhook_url` + `webhook_urls`
+     (a single editable string-list — model as one list internally and split the first
+     into `webhook_url` on `toPayload`, OR just always write `webhook_urls` and leave
+     `webhook_url` for legacy; simplest is to surface ONE "Endpoints" list bound to
+     `webhook_urls` and keep `webhook_url` as a read-through). **Decide: collapse both
+     into a single Endpoints list editing `webhook_urls`; map a lone legacy `webhook_url`
+     into the list on load and clear it on save.** Mirror `ConditionPrefixInput`-style
+     add/remove-row with stable index keys (see the admin-editor bug-class memory — avoid
+     comma round-trip / array-index key bugs).
+   - **Headers**: key/value map editor bound to `webhook_headers` (same add/remove-row
+     pattern; values may be bearer tokens → mask on display, see secret note below).
+   - **Advanced disclosure** (collapsed by default, like ReplicationPanel's): the tuning
+     fields — `tick_interval`, `batch_size`, `request_timeout`, `max_attempts`,
+     `retry_base`, `retry_max`, `stale_claim_after`, `delivered_retention`,
+     `delivered_max_rows`, `prune_batch`. Each `FormField` with YAML-path breadcrumb +
+     default-placeholder (reuse the shared `FormField`).
+   - **Apply flow**: guarded client-side validation (non-empty endpoint when enabled;
+     durations look like humantime) → `editorRunApply()` → `ApplyDialog` → confirm.
+     Register `useApplyHandler` for ⌘S.
+   - **Live delivery strip** at top: fetch `GET /_/api/admin/event-outbox?limit=1` for
+     `delivery_enabled` / `delivery_active` + status counts; render a compact
+     "Active / Inactive · N pending · N failed" banner with a link to
+     `diagnostics/event-outbox` for the full table. (Read-only; reuses existing route.)
+
+### Phase 2 — "Send test event" affordance (small, high-value)
+A button that POSTs a synthetic event to the configured endpoint(s) so an operator can
+confirm wiring without mutating an object. Two options — pick per the no-test-route rule
+in CLAUDE.md (endpoints ship only for a real production use case; a test-ping IS a real
+operator affordance, like `config/sync-now`):
+- **Preferred:** `POST /_/api/admin/event-outbox/test` — server builds a
+  `deltaglider.event.v1` payload with a sentinel key (e.g. `__webhook_test__`) and calls
+  the existing `HttpWebhookDeliveryClient::deliver` against the *current* config,
+  returning per-endpoint status. No DB row inserted (pure delivery probe). This mirrors
+  `sync-now` as a legitimate operator affordance and keeps the test path identical to
+  production delivery.
+- Frontend: a "Send test event" button in the panel → shows per-endpoint result chips.
+
+### Phase 3 — Docs + verification
+- Update `deltaglider_proxy.example.yaml` comment for `advanced.event_delivery` to point
+  at the GUI; mention it's hot-reloaded.
+- Frontend gate: `npm run lint && tsc && knip` (knip will flag the new component if not
+  wired — it IS wired via AdminPage import). Add the new panel to any barrel if needed.
+- `cargo build` (only if Phase 2 backend route added) + `cargo clippy -D warnings`.
+- Node regression: if the endpoints/headers list editors get pure helpers (split/merge,
+  dedupe), colocate a Node regression test like the `ConditionPrefixInput` reference fix
+  (admin-editor bug-class memory).
+- E2E smoke: extend an embedded-UI smoke if the existing one covers admin panels.
+
+## Risks / gotchas (verified)
+1. **Secret round-trip.** `GET .../advanced` redacts secrets; `webhook_headers` values
+   (bearer tokens) and any credential-bearing `webhook_url` must survive GET→edit→PUT
+   untouched when the operator doesn't retype them. Check how `section_level.rs:305-406`
+   preserves runtime secrets and ensure header VALUES are in that preservation set (they
+   may not be today — if a header value comes back redacted and is PUT verbatim, it would
+   overwrite the real token with the redaction sentinel). **This is the one backend item
+   to verify/extend.** If header values aren't preserved, add them to the preserve list
+   (mirror `preserve_sigv4_pair`).
+2. **`webhook_url` vs `webhook_urls` duplication.** Collapsing to one Endpoints list
+   avoids a confusing two-field UI; make the mapping lossless (legacy single URL → list
+   on load) so existing YAML configs round-trip.
+3. **Array-index keys / comma round-trip** in the endpoints + headers list editors — the
+   recurring admin-editor bug class. Use the `ConditionPrefixInput` pure-helper + stable-id
+   pattern and a Node regression test.
+4. **Don't add a test-only route.** The Phase-2 test-ping is justified ONLY as a genuine
+   operator affordance (confirm webhook wiring in prod). Frame it as such or drop it.
+
+## Effort
+~1–1.5 days. Phase 1 (panel + nav + types) is the bulk and is pure frontend mirroring an
+existing panel. Phase 2 is a small optional backend route + button. No new config shape,
+no schema work, no migration, hot-reload already works.

--- a/scripts/bump-runner-nofile.sh
+++ b/scripts/bump-runner-nofile.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Bump the open-file limit (nofile) on the self-hosted CI runners.
+#
+# WHY: the runners are Ryzen LXC containers (the `k3s` label is a historical
+# alias — no Kubernetes). LXC inherits a low default nofile (~1024). The CI
+# integration job runs ~35 test binaries in parallel, each with its own proxy +
+# MinIO sockets, so the aggregate fd count crosses 1024 and fails as
+# `ConnectError("tcp open error", Os code 24 "Too many open files")`.
+# See docs/dev/ci-infra.md → "Open-file limit (nofile)".
+#
+# RUN THIS ON THE RYZEN HOST (not in CI, not on a dev laptop). It is idempotent.
+#
+# Usage:
+#   sudo scripts/bump-runner-nofile.sh                 # auto-detect LXC containers
+#   sudo scripts/bump-runner-nofile.sh ct1 ct2 ...     # explicit container names
+#
+# Supports plain LXC (/var/lib/lxc), Incus/LXD (`incus`/`lxc` CLI), and a
+# fallback that edits the in-container actions-runner systemd unit.
+set -euo pipefail
+
+NOFILE="${NOFILE:-1048576}"
+
+log() { printf '==> %s\n' "$*"; }
+warn() { printf '!!  %s\n' "$*" >&2; }
+
+[[ $EUID -eq 0 ]] || { warn "must run as root (sudo)"; exit 1; }
+
+# ── 1. Discover containers ────────────────────────────────────────────────
+containers=("$@")
+if [[ ${#containers[@]} -eq 0 ]]; then
+  if command -v lxc-ls >/dev/null 2>&1; then
+    mapfile -t containers < <(lxc-ls -1 2>/dev/null || true)
+  elif command -v incus >/dev/null 2>&1; then
+    mapfile -t containers < <(incus list -c n --format csv 2>/dev/null || true)
+  elif command -v lxc >/dev/null 2>&1; then
+    mapfile -t containers < <(lxc list -c n --format csv 2>/dev/null || true)
+  fi
+fi
+[[ ${#containers[@]} -gt 0 ]] || { warn "no containers found — pass names explicitly"; exit 1; }
+log "Target containers: ${containers[*]}  (nofile=${NOFILE})"
+
+# ── 2. Per-container limit bump ───────────────────────────────────────────
+for ct in "${containers[@]}"; do
+  [[ -n "$ct" ]] || continue
+  log "Container: $ct"
+
+  cfg="/var/lib/lxc/$ct/config"
+  if [[ -f "$cfg" ]]; then
+    # Plain LXC: set lxc.prlimit.nofile (idempotent: drop any prior line first).
+    sed -i '/^lxc\.prlimit\.nofile/d' "$cfg"
+    printf 'lxc.prlimit.nofile = %s\n' "$NOFILE" >> "$cfg"
+    log "  set lxc.prlimit.nofile in $cfg (restart container to apply)"
+  elif command -v incus >/dev/null 2>&1; then
+    incus config set "$ct" limits.kernel.nofile "$NOFILE" \
+      && log "  set incus limits.kernel.nofile=$NOFILE (restart container to apply)"
+  elif command -v lxc >/dev/null 2>&1; then
+    lxc config set "$ct" limits.kernel.nofile "$NOFILE" \
+      && log "  set lxd limits.kernel.nofile=$NOFILE (restart container to apply)"
+  else
+    warn "  no LXC/Incus/LXD config path for $ct — bump the in-container runner unit manually:"
+    warn "    systemctl edit actions-runner  →  [Service]\\n    LimitNOFILE=$NOFILE"
+  fi
+
+  # Also pin the in-container actions-runner systemd unit if we can reach it.
+  # (Belt-and-suspenders: the host prlimit caps the ceiling, the unit raises the
+  # soft limit for the runner process itself.)
+  runner_exec="lxc-attach -n $ct --"
+  command -v incus >/dev/null 2>&1 && runner_exec="incus exec $ct --"
+  if $runner_exec true >/dev/null 2>&1; then
+    $runner_exec bash -lc '
+      set -e
+      if systemctl list-unit-files 2>/dev/null | grep -q "^actions-runner"; then
+        mkdir -p /etc/systemd/system/actions-runner.service.d
+        printf "[Service]\nLimitNOFILE='"$NOFILE"'\n" \
+          > /etc/systemd/system/actions-runner.service.d/nofile.conf
+        systemctl daemon-reload
+        systemctl restart actions-runner || true
+        echo "    in-container actions-runner LimitNOFILE pinned + restarted"
+      else
+        echo "    (no actions-runner systemd unit inside; skipping in-container unit)"
+      fi
+    ' || warn "  could not pin in-container runner unit for $ct"
+  fi
+done
+
+log "Done. Restart any container whose host-level limit changed:"
+log "  lxc-stop -n <ct> && lxc-start -n <ct>   (or: incus restart <ct>)"
+log "Verify from a CI job step:  ulimit -Sn; ulimit -Hn; cat /proc/sys/fs/file-max"

--- a/src/api/admin/config/document_level.rs
+++ b/src/api/admin/config/document_level.rs
@@ -335,6 +335,14 @@ fn preserve_runtime_secrets(
     super::preserve_primary_backend_creds(incoming, current, &mut warnings);
     super::preserve_named_backends_creds(incoming, current, &mut warnings);
 
+    // Webhook header values are masked to REDACTED_SENTINEL on export
+    // (`redact_all_secrets`). A full-document export → edit → apply
+    // round-trip (GUI "Export/Import YAML" or any GitOps flow) would
+    // otherwise persist the literal sentinel as the bearer token. Mirror
+    // the section-PUT path so the document path preserves untouched
+    // secrets identically.
+    super::preserve_event_delivery_secrets(&mut incoming.event_delivery, &current.event_delivery);
+
     warnings
 }
 

--- a/src/api/admin/config/mod.rs
+++ b/src/api/admin/config/mod.rs
@@ -572,6 +572,37 @@ pub(super) fn preserve_sigv4_pair(
     }
 }
 
+/// Preserve unredacted `event_delivery.webhook_headers` values across a section
+/// round-trip. The GET masks each header value to
+/// [`crate::config::REDACTED_SENTINEL`] (keeping the key), so an unedited
+/// round-trip would otherwise overwrite the real bearer token with the mask.
+///
+/// Per-key, three cases mirror the SigV4 "None means unchanged" contract:
+/// - value still equals the sentinel → the operator did not retype it → restore
+///   the old value (or drop the key if `old` has no such header — a masked value
+///   for a key that never existed is meaningless, treat as unset).
+/// - value differs from the sentinel → the operator typed a real value → keep it.
+/// - key absent from `new` → the operator removed it (the merge-patch already
+///   applied the delete) → nothing to do here.
+pub(super) fn preserve_event_delivery_secrets(
+    new: &mut crate::config_sections::EventDeliveryConfig,
+    old: &crate::config_sections::EventDeliveryConfig,
+) {
+    let sentinel = crate::config::REDACTED_SENTINEL;
+    let mut drop_keys: Vec<String> = Vec::new();
+    for (key, value) in new.webhook_headers.iter_mut() {
+        if value == sentinel {
+            match old.webhook_headers.get(key) {
+                Some(prev) => *value = prev.clone(),
+                None => drop_keys.push(key.clone()),
+            }
+        }
+    }
+    for key in drop_keys {
+        new.webhook_headers.remove(&key);
+    }
+}
+
 /// Preserve credentials on the PRIMARY backend across a config swap.
 ///
 /// Cases handled:
@@ -929,5 +960,87 @@ pub async fn sync_now(
             tracing::warn!("sync-now failed: {e}");
             Err(axum::http::StatusCode::BAD_GATEWAY)
         }
+    }
+}
+
+#[cfg(test)]
+mod preserve_tests {
+    use super::*;
+    use crate::config::REDACTED_SENTINEL;
+    use crate::config_sections::EventDeliveryConfig;
+    use std::collections::BTreeMap;
+
+    fn ed_with(headers: &[(&str, &str)]) -> EventDeliveryConfig {
+        EventDeliveryConfig {
+            webhook_headers: headers
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
+            ..EventDeliveryConfig::default()
+        }
+    }
+
+    #[test]
+    fn preserve_restores_untouched_sentinel_value() {
+        // Operator left "Authorization" masked → restore the old token.
+        let old = ed_with(&[("Authorization", "Bearer real-token")]);
+        let mut new = ed_with(&[("Authorization", REDACTED_SENTINEL)]);
+        preserve_event_delivery_secrets(&mut new, &old);
+        assert_eq!(
+            new.webhook_headers.get("Authorization").map(String::as_str),
+            Some("Bearer real-token")
+        );
+    }
+
+    #[test]
+    fn preserve_keeps_retyped_value() {
+        // Operator typed a new token → keep it, don't restore the old one.
+        let old = ed_with(&[("Authorization", "Bearer old")]);
+        let mut new = ed_with(&[("Authorization", "Bearer NEW")]);
+        preserve_event_delivery_secrets(&mut new, &old);
+        assert_eq!(
+            new.webhook_headers.get("Authorization").map(String::as_str),
+            Some("Bearer NEW")
+        );
+    }
+
+    #[test]
+    fn preserve_drops_sentinel_for_unknown_key() {
+        // A masked value for a key the old config never had is meaningless → drop.
+        let old = ed_with(&[]);
+        let mut new = ed_with(&[("X-New", REDACTED_SENTINEL)]);
+        preserve_event_delivery_secrets(&mut new, &old);
+        assert!(!new.webhook_headers.contains_key("X-New"));
+    }
+
+    #[test]
+    fn preserve_leaves_removed_key_removed() {
+        // Operator removed "Authorization" (absent from new) → stays removed;
+        // a different untouched header is restored.
+        let old = ed_with(&[("Authorization", "Bearer real"), ("X-Env", "prod")]);
+        let mut new = ed_with(&[("X-Env", REDACTED_SENTINEL)]);
+        preserve_event_delivery_secrets(&mut new, &old);
+        assert!(!new.webhook_headers.contains_key("Authorization"));
+        assert_eq!(
+            new.webhook_headers.get("X-Env").map(String::as_str),
+            Some("prod")
+        );
+    }
+
+    #[test]
+    fn redact_masks_header_values_keeps_keys() {
+        // The GET-side redaction (config.rs) masks values but keeps keys.
+        let cfg = crate::config::Config {
+            event_delivery: ed_with(&[("Authorization", "Bearer secret"), ("X-Env", "prod")]),
+            ..crate::config::Config::default()
+        };
+        let redacted = cfg.redact_all_secrets();
+        let h: &BTreeMap<String, String> = &redacted.event_delivery.webhook_headers;
+        assert_eq!(
+            h.get("Authorization").map(String::as_str),
+            Some(REDACTED_SENTINEL)
+        );
+        assert_eq!(h.get("X-Env").map(String::as_str), Some(REDACTED_SENTINEL));
+        assert_eq!(h.len(), 2, "keys must survive redaction");
     }
 }

--- a/src/api/admin/config/section_level.rs
+++ b/src/api/admin/config/section_level.rs
@@ -397,6 +397,11 @@ async fn apply_section(
         }
     }
 
+    // Webhook header values are masked to REDACTED_SENTINEL on GET; restore any
+    // the operator left untouched so an unedited round-trip doesn't clobber the
+    // real bearer token. (Headers the operator retyped or removed pass through.)
+    super::preserve_event_delivery_secrets(&mut new_cfg.event_delivery, &old_cfg.event_delivery);
+
     // The `removed_warnings` name is preserved here for readability of the
     // downstream call sites that thread it into `SectionApplyResponse`.
     // It now carries the FULL cred-preservation warning bag

--- a/src/api/admin/replication.rs
+++ b/src/api/admin/replication.rs
@@ -25,6 +25,12 @@ use tracing::info;
 pub struct ReplicationOverview {
     pub worker_enabled: bool,
     pub tick_interval: String,
+    /// Replication is event-driven: this is the unix timestamp the event
+    /// consumer last advanced its outbox cursor (i.e. last applied an object
+    /// mutation). `None` if it hasn't processed anything yet. The per-rule
+    /// `next_due_at` is the slow reconcile-sweep countdown, not the primary
+    /// trigger.
+    pub last_event_applied_at: Option<i64>,
     pub rules: Vec<RuleOverview>,
 }
 
@@ -62,6 +68,7 @@ pub async fn list_rules(
             return Ok(Json(ReplicationOverview {
                 worker_enabled: repl.enabled,
                 tick_interval: repl.tick_interval.clone(),
+                last_event_applied_at: None,
                 rules: Vec::new(),
             }))
         }
@@ -93,9 +100,16 @@ pub async fn list_rules(
         });
     }
 
+    let last_event_applied_at = db
+        .listener_cursor_load_full(crate::replication::event_consumer::REPLICATION_LISTENER)
+        .ok()
+        .flatten()
+        .map(|c| c.updated_at);
+
     Ok(Json(ReplicationOverview {
         worker_enabled: repl.enabled,
         tick_interval: repl.tick_interval.clone(),
+        last_event_applied_at,
         rules: rules_out,
     }))
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -288,6 +288,14 @@ pub const DEFAULT_CONFIG_FILENAME: &str = "deltaglider_proxy.toml";
 /// Default YAML config filename (preferred for new deployments).
 pub const DEFAULT_YAML_CONFIG_FILENAME: &str = "deltaglider_proxy.yaml";
 
+/// Placeholder substituted for secret VALUES that must keep their KEY visible in
+/// a redacted export (so the GUI can show *which* secrets exist while masking the
+/// value). Used for `event_delivery.webhook_headers` values. The section-PUT
+/// preserve path treats an incoming value equal to this sentinel as "unchanged,
+/// keep the runtime secret" — see `preserve_event_delivery_secrets`. SigV4 and
+/// backend creds use `None`-omission instead (no key to preserve).
+pub const REDACTED_SENTINEL: &str = "__redacted__";
+
 /// Ordered list of default config file locations. YAML is preferred over TOML
 /// when both exist in the same directory.
 pub const DEFAULT_CONFIG_SEARCH_PATHS: &[&str] = &[
@@ -2028,6 +2036,14 @@ impl Config {
         }
         export.access_key_id = None;
         export.secret_access_key = None;
+        // Webhook header values may carry bearer tokens. Mask the VALUE but keep
+        // the KEY so the GUI shows which headers exist; the section-PUT preserve
+        // path restores any value left as this sentinel. Endpoint URLs are left
+        // visible on purpose (operators must verify them; credentials belong in
+        // headers, not the URL).
+        for value in export.event_delivery.webhook_headers.values_mut() {
+            *value = REDACTED_SENTINEL.to_string();
+        }
         export
     }
 

--- a/src/config_db/mod.rs
+++ b/src/config_db/mod.rs
@@ -25,7 +25,7 @@ pub struct ConfigDb {
 }
 
 /// Schema version — bump when adding migrations.
-const SCHEMA_VERSION: i32 = 11;
+const SCHEMA_VERSION: i32 = 12;
 
 pub(crate) mod auth_providers;
 mod declarative;
@@ -480,6 +480,25 @@ impl ConfigDb {
             )?;
             info!(
                 "Migrated config DB schema from v{} to v11 (renamed lifecycle counters)",
+                version
+            );
+        }
+
+        if version < 12 {
+            // v12: per-listener cursors over the append-only event_outbox.
+            // Event-driven replication consumes the outbox via its own
+            // high-water `last_event_id` (independent of the webhook
+            // dispatcher's global delivery status), so multiple listeners can
+            // drain the same append-only log without contention.
+            conn.execute_batch(
+                "CREATE TABLE IF NOT EXISTS listener_cursors (
+                    listener_name TEXT PRIMARY KEY,
+                    last_event_id INTEGER NOT NULL DEFAULT 0,
+                    updated_at    INTEGER NOT NULL DEFAULT (unixepoch())
+                );",
+            )?;
+            info!(
+                "Migrated config DB schema from v{} to v12 (added listener_cursors)",
                 version
             );
         }

--- a/src/config_sections.rs
+++ b/src/config_sections.rs
@@ -765,8 +765,13 @@ pub struct ReplicationRule {
     pub source: ReplicationEndpoint,
     pub destination: ReplicationEndpoint,
 
-    /// How often this rule runs. Humantime-parsed (`"15m"`, `"1h"`, ...).
-    /// Minimum enforced at config load time (`30s`).
+    /// How often the **full reconcile sweep** runs for this rule. Replication
+    /// is event-driven — object mutations are replicated in near-real time by
+    /// the event consumer — so this interval is the slow self-healing safety
+    /// net (full source list-and-diff that catches anything a dropped event
+    /// missed), NOT the primary trigger. Humantime-parsed (`"24h"`, `"6h"`,
+    /// ...); minimum enforced at config load (`30s`). Defaults to `24h`.
+    #[serde(default = "default_reconcile_interval")]
     pub interval: String,
 
     /// Objects per scheduler yield. The worker copies this many objects
@@ -804,6 +809,12 @@ fn default_rule_enabled() -> bool {
 
 fn default_batch_size() -> u32 {
     100
+}
+
+/// Default reconcile-sweep cadence. Events are the primary trigger, so the
+/// full list-and-diff only needs to run infrequently as a safety net.
+fn default_reconcile_interval() -> String {
+    "24h".to_string()
 }
 
 fn default_exclude_globs() -> Vec<String> {

--- a/src/event_delivery.rs
+++ b/src/event_delivery.rs
@@ -32,6 +32,11 @@ const DEFAULT_RETRY_MAX: Duration = Duration::from_secs(300);
 const DEFAULT_STALE_CLAIM_AFTER: Duration = Duration::from_secs(60);
 const DEFAULT_DELIVERED_RETENTION: Duration = Duration::from_secs(24 * 60 * 60);
 
+/// A listener cursor older than this (no advance in 1h) is treated as inactive
+/// and no longer pins the prune floor. A healthy consumer advances every tick
+/// (seconds), so this only ever fires for a stuck/dead/disabled listener.
+const LISTENER_CURSOR_STALE_SECS: i64 = 60 * 60;
+
 #[derive(Debug, Clone, Serialize)]
 pub struct EventWebhookPayload<'a> {
     pub schema: &'static str,
@@ -190,19 +195,37 @@ pub async fn dispatch_once(
         }
     }
 
+    // Prune FLOOR: never delete a delivered row that a slower listener (e.g.
+    // event-driven replication) hasn't consumed yet. We may only remove rows at
+    // or below the smallest ACTIVE listener cursor. A cursor that hasn't
+    // advanced within LISTENER_CURSOR_STALE_SECS (consumer disabled, a wedged
+    // rule, or a dead instance holding the lease) is treated as inactive and no
+    // longer pins the floor — otherwise the append-only outbox would grow
+    // without bound. No active listeners → no floor.
+    let min_keep_id = {
+        let db = db.lock().await;
+        db.event_outbox_min_active_listener_cursor(now, LISTENER_CURSOR_STALE_SECS)
+            .unwrap_or(None)
+            .unwrap_or(i64::MAX)
+    };
+
     let retention = delivered_retention_secs(config);
     if retention > 0 {
         let before = now.saturating_sub(retention);
         let db = db.lock().await;
-        if let Err(err) = db.event_outbox_prune_delivered_before(before, config.prune_batch) {
+        if let Err(err) =
+            db.event_outbox_prune_delivered_before(before, config.prune_batch, min_keep_id)
+        {
             warn!("Event outbox delivered prune failed: {}", err);
         }
     }
     if config.prune_batch > 0 {
         let db = db.lock().await;
-        if let Err(err) = db
-            .event_outbox_prune_delivered_over_count(config.delivered_max_rows, config.prune_batch)
-        {
+        if let Err(err) = db.event_outbox_prune_delivered_over_count(
+            config.delivered_max_rows,
+            config.prune_batch,
+            min_keep_id,
+        ) {
             warn!("Event outbox delivered count-prune failed: {}", err);
         }
     }

--- a/src/event_outbox.rs
+++ b/src/event_outbox.rs
@@ -523,10 +523,16 @@ impl ConfigDb {
         Ok(updated)
     }
 
+    /// Delete up to `limit` delivered rows older than `before`. `min_keep_id`
+    /// is the prune FLOOR — only rows with `id <= min_keep_id` are eligible, so
+    /// the pruner never removes a row a slower listener (event-driven
+    /// replication) hasn't consumed yet. Pass `i64::MAX` for no floor (e.g. when
+    /// no listeners exist).
     pub fn event_outbox_prune_delivered_before(
         &self,
         before: i64,
         limit: u32,
+        min_keep_id: i64,
     ) -> Result<usize, ConfigDbError> {
         if limit == 0 {
             return Ok(0);
@@ -539,18 +545,24 @@ impl ConfigDb {
                      WHERE status = 'delivered'
                        AND delivered_at IS NOT NULL
                        AND delivered_at < ?
+                       AND id <= ?
                      ORDER BY delivered_at ASC, id ASC
                      LIMIT ?
               )",
-            params![before, limit as i64],
+            params![before, min_keep_id, limit as i64],
         )?;
         Ok(deleted)
     }
 
+    /// Delete delivered rows beyond `max_delivered_rows` (newest kept), bounded
+    /// by `limit` per call. `min_keep_id` is the prune FLOOR (see
+    /// [`Self::event_outbox_prune_delivered_before`]) — only rows at or below it
+    /// are eligible, so a slower listener's unconsumed rows survive.
     pub fn event_outbox_prune_delivered_over_count(
         &self,
         max_delivered_rows: u32,
         limit: u32,
+        min_keep_id: i64,
     ) -> Result<usize, ConfigDbError> {
         if limit == 0 {
             return Ok(0);
@@ -563,13 +575,14 @@ impl ConfigDb {
                             SELECT id
                               FROM event_outbox
                              WHERE status = 'delivered'
+                               AND id <= ?
                              ORDER BY COALESCE(delivered_at, occurred_at) DESC, id DESC
                              LIMIT -1 OFFSET ?
                       )
                      ORDER BY id ASC
                      LIMIT ?
               )",
-            params![max_delivered_rows as i64, limit as i64],
+            params![min_keep_id, max_delivered_rows as i64, limit as i64],
         )?;
         Ok(deleted)
     }
@@ -589,6 +602,151 @@ impl ConfigDb {
             .optional()?;
         Ok(row)
     }
+
+    // === Per-listener cursor API (event-driven replication, schema v12) ===
+    //
+    // The outbox is append-only. Each listener (webhook delivery, replication)
+    // reads `WHERE id > cursor` and tracks its own high-water `last_event_id`
+    // here — it does NOT touch the global `status`/`delivered_at`, so listeners
+    // never contend. Ordering is by autoincrement `id` (true arrival order).
+
+    /// Fetch up to `limit` outbox records with `id > after_id`, oldest first.
+    /// This is the listener drain query — `id ASC` is the contract compaction
+    /// and cursor advancement rely on.
+    pub fn event_outbox_since(
+        &self,
+        after_id: i64,
+        limit: u32,
+    ) -> Result<Vec<EventOutboxRecord>, ConfigDbError> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, kind, bucket, object_key, source, occurred_at,
+                    payload_json, status, attempts, next_attempt_at,
+                    claimed_by, claimed_at, delivered_at, last_error, created_at
+               FROM event_outbox
+              WHERE id > ?
+              ORDER BY id ASC
+              LIMIT ?",
+        )?;
+        let rows = stmt
+            .query_map(params![after_id, limit as i64], event_from_row)?
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(rows)
+    }
+
+    /// The listener's current high-water `last_event_id` (0 if it has never
+    /// recorded a cursor).
+    pub fn listener_cursor_load(&self, listener: &str) -> Result<i64, ConfigDbError> {
+        let cursor = self
+            .conn
+            .query_row(
+                "SELECT last_event_id FROM listener_cursors WHERE listener_name = ?",
+                params![listener],
+                |row| row.get::<_, i64>(0),
+            )
+            .optional()?;
+        Ok(cursor.unwrap_or(0))
+    }
+
+    /// Advance the listener cursor to `new_id`. Monotonic: the stored value
+    /// never regresses (`MAX(existing, new)`), so a reordered or duplicate
+    /// advance can't move the high-water mark backwards.
+    pub fn listener_cursor_advance(
+        &self,
+        listener: &str,
+        new_id: i64,
+        now: i64,
+    ) -> Result<(), ConfigDbError> {
+        self.conn.execute(
+            "INSERT INTO listener_cursors (listener_name, last_event_id, updated_at)
+                  VALUES (?, ?, ?)
+             ON CONFLICT(listener_name) DO UPDATE SET
+                  last_event_id = MAX(last_event_id, excluded.last_event_id),
+                  updated_at    = excluded.updated_at",
+            params![listener, new_id, now],
+        )?;
+        Ok(())
+    }
+
+    /// Load the full cursor row (for surfacing "last event applied at" in the
+    /// admin UI). `None` if the listener has no cursor yet.
+    pub fn listener_cursor_load_full(
+        &self,
+        listener: &str,
+    ) -> Result<Option<ListenerCursor>, ConfigDbError> {
+        let row = self
+            .conn
+            .query_row(
+                "SELECT listener_name, last_event_id, updated_at
+                   FROM listener_cursors WHERE listener_name = ?",
+                params![listener],
+                |row| {
+                    Ok(ListenerCursor {
+                        listener_name: row.get(0)?,
+                        last_event_id: row.get(1)?,
+                        updated_at: row.get(2)?,
+                    })
+                },
+            )
+            .optional()?;
+        Ok(row)
+    }
+
+    /// The smallest `last_event_id` across ALL listener cursors, or `None` when
+    /// there are no cursors. The webhook delivered-row pruner clamps its delete
+    /// floor to this so it never removes a row a slower listener (replication)
+    /// hasn't consumed yet.
+    pub fn event_outbox_min_listener_cursor(&self) -> Result<Option<i64>, ConfigDbError> {
+        let min = self
+            .conn
+            .query_row(
+                "SELECT MIN(last_event_id) FROM listener_cursors",
+                [],
+                |row| row.get::<_, Option<i64>>(0),
+            )
+            .optional()?
+            .flatten();
+        Ok(min)
+    }
+
+    /// The smallest `last_event_id` across listener cursors that are still
+    /// ACTIVE — i.e. whose `updated_at` is within `max_age_secs` of `now`.
+    ///
+    /// A stuck or dead consumer (replication disabled mid-flight, a permanently
+    /// failing rule wedging the watermark, an instance that died holding the
+    /// consumer lease) would otherwise pin the pruner's delete floor forever and
+    /// let the outbox grow without bound. Ignoring stale cursors lets the pruner
+    /// reclaim space once a listener stops making progress; the cost is that a
+    /// listener idle longer than `max_age_secs` may have already-delivered rows
+    /// pruned out from under it — acceptable because a consumer that far behind
+    /// relies on the slow full reconcile to self-heal anyway.
+    ///
+    /// `None` when no cursor is active (→ no floor; pruner may delete any
+    /// delivered row).
+    pub fn event_outbox_min_active_listener_cursor(
+        &self,
+        now: i64,
+        max_age_secs: i64,
+    ) -> Result<Option<i64>, ConfigDbError> {
+        let cutoff = now.saturating_sub(max_age_secs);
+        let min = self
+            .conn
+            .query_row(
+                "SELECT MIN(last_event_id) FROM listener_cursors WHERE updated_at >= ?",
+                params![cutoff],
+                |row| row.get::<_, Option<i64>>(0),
+            )
+            .optional()?
+            .flatten();
+        Ok(min)
+    }
+}
+
+/// A listener's cursor row — its high-water `last_event_id` over the outbox.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ListenerCursor {
+    pub listener_name: String,
+    pub last_event_id: i64,
+    pub updated_at: i64,
 }
 
 fn event_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<EventOutboxRecord> {
@@ -713,7 +871,9 @@ mod tests {
         assert!(db.event_outbox_mark_delivered(old, 100).unwrap());
         assert!(db.event_outbox_mark_delivered(new, 300).unwrap());
 
-        let deleted = db.event_outbox_prune_delivered_before(200, 100).unwrap();
+        let deleted = db
+            .event_outbox_prune_delivered_before(200, 100, i64::MAX)
+            .unwrap();
         assert_eq!(deleted, 1);
 
         let rows = db.event_outbox_recent(10).unwrap();
@@ -772,7 +932,9 @@ mod tests {
         db.event_outbox_mark_delivered(new, 300).unwrap();
         db.event_outbox_mark_failed(failed, "dead", None).unwrap();
 
-        let deleted = db.event_outbox_prune_delivered_over_count(2, 100).unwrap();
+        let deleted = db
+            .event_outbox_prune_delivered_over_count(2, 100, i64::MAX)
+            .unwrap();
         assert_eq!(deleted, 1);
 
         let rows = db.event_outbox_recent(10).unwrap();
@@ -828,5 +990,90 @@ mod tests {
         assert_eq!(pending_row.status, STATUS_PENDING);
         assert_eq!(pending_row.next_attempt_at, None);
         assert_eq!(delivered_row.status, STATUS_DELIVERED);
+    }
+
+    #[test]
+    fn listener_cursor_load_advance_monotonic() {
+        let db = ConfigDb::in_memory("test-pass").unwrap();
+        // Absent cursor reads as 0.
+        assert_eq!(db.listener_cursor_load("replication").unwrap(), 0);
+        db.listener_cursor_advance("replication", 5, 100).unwrap();
+        assert_eq!(db.listener_cursor_load("replication").unwrap(), 5);
+        // Monotonic: a lower advance does NOT regress the high-water mark.
+        db.listener_cursor_advance("replication", 3, 110).unwrap();
+        assert_eq!(db.listener_cursor_load("replication").unwrap(), 5);
+        db.listener_cursor_advance("replication", 9, 120).unwrap();
+        assert_eq!(db.listener_cursor_load("replication").unwrap(), 9);
+        // Distinct listeners are independent.
+        assert_eq!(db.listener_cursor_load("webhook").unwrap(), 0);
+        let full = db
+            .listener_cursor_load_full("replication")
+            .unwrap()
+            .unwrap();
+        assert_eq!(full.last_event_id, 9);
+        assert_eq!(full.updated_at, 120);
+    }
+
+    #[test]
+    fn min_active_listener_cursor_ignores_stale_cursors() {
+        let db = ConfigDb::in_memory("test-pass").unwrap();
+        // Two listeners: webhook fresh at id=20 (updated_at=1000), replication
+        // stale at id=5 (updated_at=100).
+        db.listener_cursor_advance("webhook", 20, 1000).unwrap();
+        db.listener_cursor_advance("replication", 5, 100).unwrap();
+        // Plain min sees the stale replication cursor → pins the floor at 5.
+        assert_eq!(db.event_outbox_min_listener_cursor().unwrap(), Some(5));
+        // Active variant at now=1000 with a 60s staleness window: replication
+        // (updated_at=100) is stale and ignored; only webhook (1000) counts.
+        assert_eq!(
+            db.event_outbox_min_active_listener_cursor(1000, 60)
+                .unwrap(),
+            Some(20)
+        );
+        // A wide window includes both again.
+        assert_eq!(
+            db.event_outbox_min_active_listener_cursor(1000, 100_000)
+                .unwrap(),
+            Some(5)
+        );
+        // When ALL cursors are stale, there's no floor (None) → pruner is free.
+        assert_eq!(
+            db.event_outbox_min_active_listener_cursor(100_000, 60)
+                .unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn event_outbox_since_returns_id_ordered_window() {
+        let db = ConfigDb::in_memory("test-pass").unwrap();
+        let a = db.event_outbox_insert(&event_at(10, "a")).unwrap();
+        let b = db.event_outbox_insert(&event_at(20, "b")).unwrap();
+        let c = db.event_outbox_insert(&event_at(30, "c")).unwrap();
+        // Everything after `a` → b, c in id order.
+        let rows = db.event_outbox_since(a, 100).unwrap();
+        assert_eq!(rows.iter().map(|r| r.id).collect::<Vec<_>>(), vec![b, c]);
+        // Cursor at the end → empty.
+        assert!(db.event_outbox_since(c, 100).unwrap().is_empty());
+        // Limit honored.
+        assert_eq!(db.event_outbox_since(0, 1).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn prune_respects_listener_cursor_floor() {
+        let db = ConfigDb::in_memory("test-pass").unwrap();
+        let a = db.event_outbox_insert(&event_at(10, "a")).unwrap();
+        let b = db.event_outbox_insert(&event_at(20, "b")).unwrap();
+        // Both delivered long ago.
+        db.event_outbox_mark_delivered(a, 1).unwrap();
+        db.event_outbox_mark_delivered(b, 1).unwrap();
+        // Prune with floor = a (the listener has only consumed up to `a`): only
+        // `a` is eligible; `b` survives because the listener hasn't passed it.
+        let deleted = db
+            .event_outbox_prune_delivered_before(1_000_000, 100, a)
+            .unwrap();
+        assert_eq!(deleted, 1);
+        assert!(db.event_outbox_load(a).unwrap().is_none());
+        assert!(db.event_outbox_load(b).unwrap().is_some());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -630,7 +630,15 @@ async fn async_main(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
             state.clone(),
         );
         if let Some(db) = config_db.as_ref() {
+            // Reconcile scheduler — the slow (≈24h) full list-and-diff safety net.
             deltaglider_proxy::replication::scheduler::spawn_scheduler(
+                shared_config.clone(),
+                db.clone(),
+                state.clone(),
+            );
+            // Event-driven consumer — the PRIMARY trigger: drains object
+            // mutations from the outbox and replicates in near-real time.
+            deltaglider_proxy::replication::event_consumer::spawn_event_consumer(
                 shared_config.clone(),
                 db.clone(),
                 state.clone(),

--- a/src/replication/event_consumer.rs
+++ b/src/replication/event_consumer.rs
@@ -1,0 +1,826 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+//! Event-driven replication consumer.
+//!
+//! Replication is **event-driven**: object mutations (PUT/DELETE/COPY/
+//! CompleteMultipartUpload) are appended to the durable `event_outbox` by the
+//! S3 write path, and this consumer drains them in near-real time, fanning each
+//! object out to the replication rules whose `source` matches. A slow per-rule
+//! full reconcile (`worker::run_rule`, default 24h) is the self-healing safety
+//! net — events are the primary trigger.
+//!
+//! ## Pub/sub via a per-listener cursor
+//!
+//! The outbox is append-only. Each independent listener (webhook delivery and
+//! replication) keeps its OWN high-water `last_event_id` in `listener_cursors`
+//! and reads `WHERE id > cursor`. The two listeners never contend on a shared
+//! status column. Ordering is by the autoincrement `id` (the true arrival
+//! order) — NOT `occurred_at`, which is wall-clock and can tie or regress.
+//!
+//! ## Per-key compaction
+//!
+//! Before acting, the consumer collapses all pending events for a single
+//! `(bucket, key)` into ONE *liveness* verdict (Copy / Delete / Noop) via
+//! [`compact_key_events`] — so create+modify+delete within one drain is a
+//! single net action, not three. The actual Copy-vs-skip / Delete-vs-noop
+//! idempotency is then the planner's job (`should_replicate` + a dest HEAD),
+//! keeping the decision logic in exactly one place shared with reconcile.
+//!
+//! This module hosts the PURE helpers (filtering, compaction, routing); they
+//! are unit-tested without any I/O. The background loop is `spawn_event_consumer`.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use tokio::sync::Mutex;
+use tracing::{debug, info, warn};
+
+use crate::api::handlers::AppState;
+use crate::config::SharedConfig;
+use crate::config_db::ConfigDb;
+use crate::config_sections::ReplicationRule;
+use crate::event_outbox::{
+    current_unix_seconds, EventKind, EventOutboxRecord, EventSource, NewEvent,
+};
+use crate::transfer::{
+    copy_object_with_retries, ObjectTransferRequest, TransferProvenance,
+    REPLICATION_RULE_METADATA_KEY,
+};
+
+use super::planner::{
+    compile_rule_globs, normalize_prefix, rewrite_key, should_replicate, Decision,
+};
+
+/// The listener name under which event-driven replication tracks its outbox
+/// cursor (independent of the webhook dispatcher).
+pub const REPLICATION_LISTENER: &str = "replication";
+
+/// The sentinel "rule name" the consumer's single-flight lease is keyed under,
+/// so only one instance drains+advances the shared cursor at a time.
+const CONSUMER_LEASE_KEY: &str = "__event_consumer__";
+
+/// Max events drained per tick.
+const DRAIN_BATCH: u32 = 500;
+
+/// The net effect a batch of events has on a single object's destination copy.
+/// Compaction reduces N events for one key to one of these; the consumer then
+/// confirms the actual action against the destination via the planner.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeyAction {
+    /// The key's final state is "present" — (re)copy it to the destination.
+    Copy,
+    /// The key's final state is "absent" — delete it at the destination (if we
+    /// wrote it there and the rule replicates deletes).
+    Delete,
+    /// No events / nothing to do.
+    Noop,
+}
+
+/// Event kinds whose effect leaves the object PRESENT at the source.
+fn is_present_producing(kind: &str) -> bool {
+    matches!(
+        kind,
+        "ObjectCreated" | "ObjectCopied" | "ReplicationObjectCopied" | "LifecycleTransitioned"
+    )
+}
+
+/// Event kinds whose effect leaves the object ABSENT at the source.
+fn is_absent_producing(kind: &str) -> bool {
+    matches!(kind, "ObjectDeleted" | "LifecycleExpired")
+}
+
+/// Collapse a key's events (in ascending `id`/arrival order) to one liveness
+/// verdict. **Last-event-wins**: the final event decides whether the source
+/// object ends up present (→ `Copy`) or absent (→ `Delete`); an empty slice or
+/// a final event of an unrecognized kind is `Noop`.
+///
+/// Rationale (locked decision): compaction only yields *liveness*. Whether a
+/// `Copy` actually transfers (vs. dest already current) and whether a `Delete`
+/// actually removes (vs. dest never had it) is decided downstream by the
+/// planner + a dest HEAD — so idempotency lives in ONE place, not a second
+/// per-key table.
+///
+/// `kinds` are the raw `EventOutboxRecord::kind` strings in id order.
+pub fn compact_key_events(kinds: &[&str]) -> KeyAction {
+    match kinds.last() {
+        None => KeyAction::Noop,
+        Some(k) if is_absent_producing(k) => KeyAction::Delete,
+        Some(k) if is_present_producing(k) => KeyAction::Copy,
+        // Unknown terminal kind (shouldn't happen for object events): do nothing.
+        Some(_) => KeyAction::Noop,
+    }
+}
+
+/// `true` for keys that represent a real user object — i.e. NOT a directory
+/// marker, DeltaGlider config-sync internal, or storage-layer delta artifact
+/// (`reference.bin`, `*.delta`). Shared by the write-path emit filter and the
+/// consumer's routing so DG internals never generate replication work.
+///
+/// Mirrors the guard set in `planner::should_replicate` (`:186-201`) so the
+/// emit filter and the planner agree on what's a user object.
+pub fn is_user_object_key(key: &str) -> bool {
+    if key.ends_with('/') {
+        return false; // directory marker
+    }
+    if key.starts_with(".deltaglider/") || key.contains("/.deltaglider/") {
+        return false; // config-sync internal
+    }
+    // Storage-layer delta artifacts. The engine listing usually hides these,
+    // but filter defensively at the source boundary.
+    let filename = key.rsplit('/').next().unwrap_or(key);
+    if filename == "reference.bin" || filename.ends_with(".delta") {
+        return false;
+    }
+    true
+}
+
+/// `true` iff the destination object carries THIS rule's provenance marker —
+/// i.e. replication wrote it. The delete-pass (event-driven and reconcile)
+/// keys off this so it only ever removes objects we created, never a
+/// foreign/pre-existing object that happens to share a key. This is the
+/// delete-safety lynchpin; it has an exhaustive unit truth-table.
+pub fn owned_by_rule(meta: &crate::types::FileMetadata, rule_name: &str) -> bool {
+    meta.user_metadata
+        .get(REPLICATION_RULE_METADATA_KEY)
+        .map(|v| v == rule_name)
+        .unwrap_or(false)
+}
+
+/// The highest CONTIGUOUS event id that fully succeeded, given the drained
+/// `rows` (ascending by id) and the set of ids whose key-action failed. Walk
+/// ascending and stop at the first failed id: the cursor only ever moves
+/// forward and never revisits, so advancing PAST a failed id would lose that
+/// event permanently. Returns `cursor` unchanged when the first row already
+/// failed.
+fn contiguous_watermark(
+    rows: &[EventOutboxRecord],
+    failed_ids: &std::collections::BTreeSet<i64>,
+    cursor: i64,
+) -> i64 {
+    let mut watermark = cursor;
+    for rec in rows {
+        if failed_ids.contains(&rec.id) {
+            break;
+        }
+        watermark = rec.id;
+    }
+    watermark
+}
+
+/// Group outbox records by `(bucket, key)`, preserving id order within each
+/// group (the input MUST already be ascending by id). The returned map's values
+/// are the records for that key, oldest first — exactly what compaction wants.
+pub fn group_events_by_key<'a>(
+    records: &'a [EventOutboxRecord],
+) -> BTreeMap<(&'a str, &'a str), Vec<&'a EventOutboxRecord>> {
+    let mut groups: BTreeMap<(&'a str, &'a str), Vec<&'a EventOutboxRecord>> = BTreeMap::new();
+    for rec in records {
+        groups
+            .entry((rec.bucket.as_str(), rec.key.as_str()))
+            .or_default()
+            .push(rec);
+    }
+    groups
+}
+
+/// Find the enabled replication rules whose `source` matches `(bucket, key)`:
+/// same source bucket AND `key` falls under the (normalized) source prefix AND
+/// the key is a user object. Glob include/exclude filtering is applied by the
+/// caller via the planner (kept here to the cheap, allocation-free predicate so
+/// the consumer can pre-filter before compiling globsets).
+///
+/// A key may match multiple rules — all are returned; the consumer fans the
+/// action out to each.
+pub fn match_rules<'a>(
+    rules: &'a [ReplicationRule],
+    bucket: &str,
+    key: &str,
+) -> Vec<&'a ReplicationRule> {
+    if !is_user_object_key(key) {
+        return Vec::new();
+    }
+    rules
+        .iter()
+        .filter(|rule| rule.enabled)
+        .filter(|rule| rule.source.bucket == bucket)
+        .filter(|rule| {
+            let prefix = normalize_prefix(&rule.source.prefix);
+            // Empty normalized prefix == whole bucket; otherwise require the key
+            // to live under it (prefix already carries a trailing slash, so this
+            // is a true path-boundary match, not a substring one).
+            prefix.is_empty() || key.starts_with(&prefix)
+        })
+        .collect()
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Background consumer loop
+// ─────────────────────────────────────────────────────────────────────────
+
+/// Spawn the event-driven replication consumer. One per process; mirrors the
+/// webhook dispatcher (`event_delivery::spawn_dispatcher`). Each tick it drains
+/// new outbox events past its cursor and applies them to matching rules.
+pub fn spawn_event_consumer(
+    config: SharedConfig,
+    db: Arc<Mutex<ConfigDb>>,
+    state: Arc<AppState>,
+) -> tokio::task::JoinHandle<()> {
+    let instance_id = format!("event-consumer:{}", uuid::Uuid::new_v4());
+    tokio::spawn(async move {
+        info!(
+            "Replication event consumer started: instance_id={}",
+            instance_id
+        );
+        loop {
+            let replication = { config.read().await.replication.clone() };
+            let tick = super::scheduler::scheduler_tick(&replication);
+            tokio::time::sleep(tick).await;
+
+            if !replication.enabled {
+                debug!("Event consumer skipped: replication disabled");
+                continue;
+            }
+            // Seed the cursor at the current MAX(id) on first ENABLED boot so a
+            // fresh consumer does NOT replay the entire historical outbox as
+            // "new" — reconcile covers pre-existing state. Deliberately done
+            // AFTER the `enabled` gate: a webhook-only deployment (replication
+            // disabled) must never create a `replication` cursor row, because
+            // that row pins the webhook pruner's delete floor
+            // (`event_outbox_min_listener_cursor`) and would otherwise let the
+            // outbox grow without bound while replication never advances it.
+            seed_cursor_if_absent(&db).await;
+            // Single-flight: only the consumer-lease holder drains+advances the
+            // shared cursor, so two instances can't both move it / double-copy.
+            //
+            // The lease is acquired once per tick and NOT renewed mid-drain
+            // (unlike the reconcile worker's heartbeat). A drain exceeding the
+            // TTL can therefore let a second instance steal the lease and
+            // overlap on the same cursor window. That is intentionally tolerated
+            // because every action is idempotent: a re-Copy is gated by a dest
+            // HEAD + `should_replicate` (a no-op when current), and a re-Delete
+            // is provenance-guarded + HEADs an already-absent dest. The cursor
+            // advance is monotonic (`MAX`), so overlap costs duplicate WORK, not
+            // correctness. Per-rule leases below add a second mutual-exclusion
+            // layer for the common case.
+            let lease_ttl = super::scheduler::lease_ttl_secs(&replication);
+            let now = current_unix_seconds();
+            let acquired = {
+                let dbg = db.lock().await;
+                let _ = dbg.replication_ensure_state(CONSUMER_LEASE_KEY, now);
+                dbg.replication_try_acquire_lease(CONSUMER_LEASE_KEY, &instance_id, now, lease_ttl)
+                    .unwrap_or(false)
+            };
+            if !acquired {
+                debug!("Event consumer tick skipped: another instance holds the lease");
+                continue;
+            }
+
+            drain_once(&db, &state, &replication, &instance_id, now).await;
+
+            let dbg = db.lock().await;
+            let _ = dbg.replication_release_lease(CONSUMER_LEASE_KEY, &instance_id);
+        }
+    })
+}
+
+/// Seed the replication cursor to `MAX(event_outbox.id)` if it has no cursor yet
+/// (don't replay history on first feature boot).
+async fn seed_cursor_if_absent(db: &Arc<Mutex<ConfigDb>>) {
+    let dbg = db.lock().await;
+    if dbg.listener_cursor_load(REPLICATION_LISTENER).unwrap_or(0) == 0 {
+        // Read the newest event id; advance the cursor to it so only events
+        // after this moment are treated as live.
+        let max_id = dbg
+            .event_outbox_recent(1)
+            .ok()
+            .and_then(|rows| rows.first().map(|r| r.id))
+            .unwrap_or(0);
+        if max_id > 0 {
+            let _ =
+                dbg.listener_cursor_advance(REPLICATION_LISTENER, max_id, current_unix_seconds());
+        }
+    }
+}
+
+/// One drain pass: read new events, group + compact per key, route to rules,
+/// act (copy/delete) under the per-rule lease, and advance the cursor to the
+/// highest CONTIGUOUS fully-handled id.
+async fn drain_once(
+    db: &Arc<Mutex<ConfigDb>>,
+    state: &Arc<AppState>,
+    replication: &crate::config_sections::ReplicationConfig,
+    instance_id: &str,
+    now: i64,
+) {
+    let cursor = {
+        let dbg = db.lock().await;
+        dbg.listener_cursor_load(REPLICATION_LISTENER).unwrap_or(0)
+    };
+    let rows = {
+        let dbg = db.lock().await;
+        match dbg.event_outbox_since(cursor, DRAIN_BATCH) {
+            Ok(r) => r,
+            Err(e) => {
+                warn!("event consumer: failed to read outbox: {e}");
+                return;
+            }
+        }
+    };
+    if rows.is_empty() {
+        return;
+    }
+
+    let lease_ttl = super::scheduler::lease_ttl_secs(replication);
+    let engine = state.engine.load();
+
+    // Compile globsets once per drain, keyed by rule name.
+    let groups = group_events_by_key(&rows);
+
+    // Track the highest contiguous id fully handled. We process keys in id
+    // order of their LAST event; but the safe contiguous watermark is computed
+    // over the raw rows: walk rows ascending and stop advancing at the first id
+    // whose key-action failed.
+    let mut failed_ids: std::collections::BTreeSet<i64> = std::collections::BTreeSet::new();
+
+    for ((bucket, key), recs) in &groups {
+        let kinds: Vec<&str> = recs.iter().map(|r| r.kind.as_str()).collect();
+        let action = compact_key_events(&kinds);
+        if action == KeyAction::Noop {
+            continue;
+        }
+        let max_id_for_key = recs.iter().map(|r| r.id).max().unwrap_or(0);
+
+        let matched = match_rules(&replication.rules, bucket, key);
+        if matched.is_empty() {
+            continue; // no rule cares about this key; it's still "handled"
+        }
+
+        for rule in matched {
+            // Respect the SAME per-rule lease the scheduler/reconcile uses, so
+            // fast-path + reconcile + multi-instance are mutually exclusive.
+            let got = {
+                let dbg = db.lock().await;
+                let _ = dbg.replication_ensure_state(&rule.name, now);
+                dbg.replication_try_acquire_lease(&rule.name, instance_id, now, lease_ttl)
+                    .unwrap_or(false)
+            };
+            if !got {
+                // Busy on another worker — leave for next tick (don't advance
+                // past this key's events).
+                failed_ids.insert(max_id_for_key);
+                continue;
+            }
+
+            let outcome = apply_action(&engine, db, rule, bucket, key, action).await;
+
+            {
+                let dbg = db.lock().await;
+                let _ = dbg.replication_release_lease(&rule.name, instance_id);
+            }
+
+            if let Err(err) = outcome {
+                warn!(
+                    "event consumer: rule '{}' {:?} {}/{} failed: {}",
+                    rule.name, action, bucket, key, err
+                );
+                let dbg = db.lock().await;
+                let _ = dbg.replication_record_failure(
+                    &rule.name,
+                    crate::replication::state_store::FailureInsert {
+                        run_id: None,
+                        occurred_at: now,
+                        source_key: key,
+                        dest_key: key,
+                        error_message: &err.to_string(),
+                    },
+                    replication.max_failures_retained,
+                );
+                failed_ids.insert(max_id_for_key);
+            }
+        }
+    }
+
+    // Advance the cursor to the highest CONTIGUOUS id with no failure (anything
+    // at or past the first failed id is left for next tick → at-least-once).
+    let watermark = contiguous_watermark(&rows, &failed_ids, cursor);
+    if watermark > cursor {
+        let dbg = db.lock().await;
+        let _ =
+            dbg.listener_cursor_advance(REPLICATION_LISTENER, watermark, current_unix_seconds());
+        debug!(
+            "event consumer: cursor {} -> {} ({} events drained)",
+            cursor,
+            watermark,
+            rows.len()
+        );
+    }
+}
+
+/// Apply one compacted action for one (rule, key): the planner + dest HEAD
+/// decide whether it actually copies/deletes (idempotency lives here, shared
+/// with reconcile).
+async fn apply_action(
+    engine: &Arc<crate::deltaglider::DynEngine>,
+    db: &Arc<Mutex<ConfigDb>>,
+    rule: &ReplicationRule,
+    bucket: &str,
+    key: &str,
+    action: KeyAction,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let dest_key = rewrite_key(&rule.source.prefix, &rule.destination.prefix, key)?;
+
+    match action {
+        KeyAction::Noop => Ok(()),
+        KeyAction::Copy => {
+            // Source may have been deleted after the event landed — HEAD it.
+            let src_meta = match engine.head(bucket, key).await {
+                Ok(m) => m,
+                Err(crate::deltaglider::EngineError::NotFound(_)) => {
+                    // Source gone — nothing to copy; reconcile/the delete event
+                    // will handle removal. Treat as handled.
+                    return Ok(());
+                }
+                Err(e) => return Err(Box::new(e)),
+            };
+            let dest_meta = engine.head(&rule.destination.bucket, &dest_key).await.ok();
+            let (include_globs, exclude_globs) = compile_rule_globs(rule)?;
+            let decision = should_replicate(
+                key,
+                &src_meta,
+                dest_meta.as_ref(),
+                rule.conflict,
+                &include_globs,
+                &exclude_globs,
+            );
+            match decision {
+                // `should_replicate` echoes the SOURCE key in `dest_key` (it
+                // never rewrites), so we always use the prefix-rewritten
+                // `dest_key` computed above — same as the reconcile worker.
+                Decision::Copy { .. } => {
+                    let transfer = ObjectTransferRequest {
+                        source_bucket: &rule.source.bucket,
+                        source_key: key,
+                        destination_bucket: &rule.destination.bucket,
+                        destination_key: &dest_key,
+                        provenance: Some(TransferProvenance {
+                            metadata_key: REPLICATION_RULE_METADATA_KEY,
+                            metadata_value: &rule.name,
+                        }),
+                        operation: "replication-event",
+                    };
+                    let outcome = copy_object_with_retries(engine, transfer).await?;
+                    // Emit ReplicationObjectCopied so the chain is observable
+                    // (mirrors the reconcile worker).
+                    emit_replication_copied(db, rule, key, &dest_key, outcome.bytes_copied).await;
+                    Ok(())
+                }
+                Decision::Skip { .. } => Ok(()),
+            }
+        }
+        KeyAction::Delete => {
+            if !rule.replicate_deletes {
+                return Ok(());
+            }
+            // Only delete a dest object WE wrote (provenance marker), mirroring
+            // the reconcile delete-pass safety property.
+            match engine.head(&rule.destination.bucket, &dest_key).await {
+                Ok(meta) => {
+                    if owned_by_rule(&meta, &rule.name) {
+                        engine.delete(&rule.destination.bucket, &dest_key).await?;
+                    }
+                    Ok(())
+                }
+                // Dest absent → nothing to delete.
+                Err(crate::deltaglider::EngineError::NotFound(_)) => Ok(()),
+                Err(e) => Err(Box::new(e)),
+            }
+        }
+    }
+}
+
+/// Append a `ReplicationObjectCopied` event (best-effort) so the replication
+/// chain is observable downstream, identical to the reconcile worker.
+async fn emit_replication_copied(
+    db: &Arc<Mutex<ConfigDb>>,
+    rule: &ReplicationRule,
+    source_key: &str,
+    dest_key: &str,
+    bytes_copied: usize,
+) {
+    let dbg = db.lock().await;
+    let _ = dbg.event_outbox_insert(&NewEvent::new(
+        EventKind::ReplicationObjectCopied,
+        rule.destination.bucket.as_str(),
+        dest_key,
+        EventSource::Replication,
+        current_unix_seconds(),
+        serde_json::json!({
+            "rule_name": &rule.name,
+            "source_bucket": &rule.source.bucket,
+            "source_key": source_key,
+            "destination_bucket": &rule.destination.bucket,
+            "destination_key": dest_key,
+            "content_length": bytes_copied,
+            "trigger": "event",
+        }),
+    ));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config_sections::{ConflictPolicy, ReplicationEndpoint, ReplicationRule};
+
+    fn rule(name: &str, src_bucket: &str, src_prefix: &str, enabled: bool) -> ReplicationRule {
+        ReplicationRule {
+            name: name.to_string(),
+            enabled,
+            source: ReplicationEndpoint {
+                bucket: src_bucket.to_string(),
+                prefix: src_prefix.to_string(),
+            },
+            destination: ReplicationEndpoint {
+                bucket: "dest".to_string(),
+                prefix: String::new(),
+            },
+            interval: "24h".to_string(),
+            batch_size: 100,
+            replicate_deletes: false,
+            conflict: ConflictPolicy::default(),
+            include_globs: Vec::new(),
+            exclude_globs: Vec::new(),
+        }
+    }
+
+    // ── compact_key_events ──────────────────────────────────────────────────
+    #[test]
+    fn compact_empty_is_noop() {
+        assert_eq!(compact_key_events(&[]), KeyAction::Noop);
+    }
+
+    #[test]
+    fn compact_single_create_is_copy() {
+        assert_eq!(compact_key_events(&["ObjectCreated"]), KeyAction::Copy);
+    }
+
+    #[test]
+    fn compact_create_then_modify_is_copy() {
+        // create + overwrite (another create) → net present → one Copy.
+        assert_eq!(
+            compact_key_events(&["ObjectCreated", "ObjectCreated"]),
+            KeyAction::Copy
+        );
+    }
+
+    #[test]
+    fn compact_create_modify_delete_is_delete() {
+        // create + modify + delete within the window → net absent → Delete.
+        assert_eq!(
+            compact_key_events(&["ObjectCreated", "ObjectCreated", "ObjectDeleted"]),
+            KeyAction::Delete
+        );
+    }
+
+    #[test]
+    fn compact_delete_after_create_is_delete() {
+        assert_eq!(
+            compact_key_events(&["ObjectCreated", "ObjectDeleted"]),
+            KeyAction::Delete
+        );
+    }
+
+    #[test]
+    fn compact_recreate_after_delete_is_copy() {
+        // delete then re-create → final present → Copy.
+        assert_eq!(
+            compact_key_events(&["ObjectDeleted", "ObjectCreated"]),
+            KeyAction::Copy
+        );
+    }
+
+    #[test]
+    fn compact_lifecycle_kinds() {
+        assert_eq!(compact_key_events(&["LifecycleExpired"]), KeyAction::Delete);
+        assert_eq!(
+            compact_key_events(&["LifecycleTransitioned"]),
+            KeyAction::Copy
+        );
+    }
+
+    #[test]
+    fn compact_unknown_terminal_kind_is_noop() {
+        assert_eq!(compact_key_events(&["SomethingElse"]), KeyAction::Noop);
+        // ...but a recognized kind AFTER an unknown one still decides.
+        assert_eq!(
+            compact_key_events(&["SomethingElse", "ObjectDeleted"]),
+            KeyAction::Delete
+        );
+    }
+
+    // ── is_user_object_key ──────────────────────────────────────────────────
+    #[test]
+    fn user_object_key_filters_internals() {
+        assert!(is_user_object_key("ror/builds/x.zip"));
+        assert!(is_user_object_key("a"));
+        assert!(!is_user_object_key("ror/builds/")); // dir marker
+        assert!(!is_user_object_key(".deltaglider/state.json"));
+        assert!(!is_user_object_key("bucket/.deltaglider/x"));
+        assert!(!is_user_object_key("ror/.dg/reference.bin"));
+        assert!(!is_user_object_key("reference.bin"));
+        assert!(!is_user_object_key("ror/libs/foo.delta"));
+        // a key that merely CONTAINS "reference.bin" as a substring is fine
+        assert!(is_user_object_key("ror/reference.bin.bak"));
+    }
+
+    // ── group_events_by_key ────────────────────────────────────────────────
+    fn rec(id: i64, bucket: &str, key: &str, kind: &str) -> EventOutboxRecord {
+        EventOutboxRecord {
+            id,
+            kind: kind.to_string(),
+            bucket: bucket.to_string(),
+            key: key.to_string(),
+            source: "s3_api".to_string(),
+            occurred_at: 0,
+            payload: serde_json::json!({}),
+            status: "pending".to_string(),
+            attempts: 0,
+            next_attempt_at: None,
+            claimed_by: None,
+            claimed_at: None,
+            delivered_at: None,
+            last_error: None,
+            created_at: 0,
+        }
+    }
+
+    #[test]
+    fn group_preserves_id_order_within_key() {
+        let recs = vec![
+            rec(1, "b", "k1", "ObjectCreated"),
+            rec(2, "b", "k2", "ObjectCreated"),
+            rec(3, "b", "k1", "ObjectDeleted"),
+        ];
+        let groups = group_events_by_key(&recs);
+        let k1 = groups.get(&("b", "k1")).unwrap();
+        assert_eq!(
+            k1.iter().map(|r| r.kind.as_str()).collect::<Vec<_>>(),
+            vec!["ObjectCreated", "ObjectDeleted"]
+        );
+        // and that group compacts to Delete.
+        let kinds: Vec<&str> = k1.iter().map(|r| r.kind.as_str()).collect();
+        assert_eq!(compact_key_events(&kinds), KeyAction::Delete);
+        assert_eq!(groups.get(&("b", "k2")).unwrap().len(), 1);
+    }
+
+    // ── match_rules ─────────────────────────────────────────────────────────
+    #[test]
+    fn match_rules_by_bucket_and_prefix() {
+        let rules = vec![
+            rule("builds", "beshu", "ror/builds/", true),
+            rule("e2e", "beshu", "ror/e2e_reports/", true),
+            rule("other-bucket", "scratch", "", true),
+            rule("disabled", "beshu", "ror/builds/", false),
+        ];
+        // A builds key → only the builds rule (disabled one excluded).
+        let m = match_rules(&rules, "beshu", "ror/builds/1.0/x.zip");
+        assert_eq!(
+            m.iter().map(|r| r.name.as_str()).collect::<Vec<_>>(),
+            vec!["builds"]
+        );
+        // Wrong bucket → nothing.
+        assert!(match_rules(&rules, "beshu", "private/x").is_empty());
+        // A whole-bucket rule matches any key in its bucket.
+        assert_eq!(
+            match_rules(&rules, "scratch", "anything/deep/x")
+                .iter()
+                .map(|r| r.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["other-bucket"]
+        );
+    }
+
+    #[test]
+    fn match_rules_prefix_boundary_not_substring() {
+        let rules = vec![rule("libs", "beshu", "ror/libs/", true)];
+        // `ror/libs-internal/` must NOT match the `ror/libs/` prefix (boundary).
+        assert!(match_rules(&rules, "beshu", "ror/libs-internal/x").is_empty());
+        assert!(!match_rules(&rules, "beshu", "ror/libs/x").is_empty());
+    }
+
+    #[test]
+    fn match_rules_skips_internal_keys() {
+        let rules = vec![rule("all", "beshu", "", true)];
+        assert!(match_rules(&rules, "beshu", "ror/.dg/reference.bin").is_empty());
+        assert!(match_rules(&rules, "beshu", "x/").is_empty()); // dir marker
+        assert!(!match_rules(&rules, "beshu", "ror/real.zip").is_empty());
+    }
+
+    #[test]
+    fn match_rules_multi_rule_fanout() {
+        let rules = vec![
+            rule("a", "beshu", "ror/", true),
+            rule("b", "beshu", "ror/builds/", true),
+        ];
+        // A builds key is under BOTH ror/ and ror/builds/ → matches both.
+        let m = match_rules(&rules, "beshu", "ror/builds/x");
+        assert_eq!(m.len(), 2);
+    }
+
+    // ── EventKind ↔ liveness coupling ───────────────────────────────────────
+    // GUARD: compaction matches raw `EventKind::as_str` strings. If a variant's
+    // string drifts and is no longer classified as present/absent producing,
+    // compaction silently treats it as Noop and the cursor advances PAST the
+    // event — a silent replication drop. This test pins every variant to its
+    // expected liveness so a rename has to update both sides.
+    #[test]
+    fn every_event_kind_has_a_liveness_classification() {
+        use EventKind::*;
+        let cases = [
+            (ObjectCreated, KeyAction::Copy),
+            (ObjectCopied, KeyAction::Copy),
+            (ReplicationObjectCopied, KeyAction::Copy),
+            (LifecycleTransitioned, KeyAction::Copy),
+            (ObjectDeleted, KeyAction::Delete),
+            (LifecycleExpired, KeyAction::Delete),
+        ];
+        for (kind, expected) in cases {
+            let s = kind.as_str();
+            assert_eq!(
+                compact_key_events(&[s]),
+                expected,
+                "EventKind::{kind:?} ({s:?}) is no longer classified as {expected:?} — \
+                 update is_present_producing/is_absent_producing to match as_str"
+            );
+            // And it must be classified by EXACTLY one of the two predicates.
+            assert_ne!(
+                is_present_producing(s),
+                is_absent_producing(s),
+                "EventKind::{kind:?} must be present XOR absent producing"
+            );
+        }
+    }
+
+    // ── owned_by_rule (delete-safety lynchpin) ──────────────────────────────
+    fn meta_with_marker(value: Option<&str>) -> crate::types::FileMetadata {
+        let mut m = crate::types::FileMetadata::fallback(
+            "k".to_string(),
+            0,
+            String::new(),
+            chrono::Utc::now(),
+            None,
+            crate::types::StorageInfo::Passthrough,
+        );
+        if let Some(v) = value {
+            m.user_metadata
+                .insert(REPLICATION_RULE_METADATA_KEY.to_string(), v.to_string());
+        }
+        m
+    }
+
+    #[test]
+    fn owned_by_rule_truth_table() {
+        // marker present and matches the rule → ours.
+        assert!(owned_by_rule(&meta_with_marker(Some("builds")), "builds"));
+        // marker present but a DIFFERENT rule → not ours (never delete).
+        assert!(!owned_by_rule(&meta_with_marker(Some("e2e")), "builds"));
+        // no marker at all (foreign / pre-existing object) → not ours.
+        assert!(!owned_by_rule(&meta_with_marker(None), "builds"));
+        // empty marker value never matches a real rule name.
+        assert!(!owned_by_rule(&meta_with_marker(Some("")), "builds"));
+    }
+
+    // ── contiguous_watermark ────────────────────────────────────────────────
+    fn rec_id(id: i64) -> EventOutboxRecord {
+        rec(id, "b", "k", "ObjectCreated")
+    }
+
+    #[test]
+    fn watermark_advances_to_last_when_nothing_failed() {
+        let rows = vec![rec_id(3), rec_id(5), rec_id(8)];
+        let failed = std::collections::BTreeSet::new();
+        assert_eq!(contiguous_watermark(&rows, &failed, 0), 8);
+    }
+
+    #[test]
+    fn watermark_stops_before_first_failed_id() {
+        let rows = vec![rec_id(3), rec_id(5), rec_id(8)];
+        let failed: std::collections::BTreeSet<i64> = [5].into_iter().collect();
+        // Advances to 3 (the last good id BEFORE the failed 5); 8 is held back
+        // even though it succeeded — at-least-once, retried next tick.
+        assert_eq!(contiguous_watermark(&rows, &failed, 0), 3);
+    }
+
+    #[test]
+    fn watermark_holds_cursor_when_first_row_failed() {
+        let rows = vec![rec_id(3), rec_id(5)];
+        let failed: std::collections::BTreeSet<i64> = [3].into_iter().collect();
+        assert_eq!(contiguous_watermark(&rows, &failed, 2), 2);
+    }
+
+    #[test]
+    fn watermark_empty_rows_returns_cursor() {
+        let rows: Vec<EventOutboxRecord> = vec![];
+        let failed = std::collections::BTreeSet::new();
+        assert_eq!(contiguous_watermark(&rows, &failed, 7), 7);
+    }
+}

--- a/src/replication/mod.rs
+++ b/src/replication/mod.rs
@@ -17,6 +17,7 @@
 //! each rule's persisted `next_due_at`, skips paused/disabled rules, and
 //! executes due rules via the same worker used by "Run now".
 
+pub mod event_consumer;
 pub mod planner;
 pub mod scheduler;
 pub mod state_store;

--- a/src/s3_adapter_s3s.rs
+++ b/src/s3_adapter_s3s.rs
@@ -57,6 +57,38 @@ impl DeltaGliderS3Service {
     pub fn state(&self) -> &Arc<AppState> {
         &self.state
     }
+
+    /// Append an object-mutation event to the durable outbox (best-effort).
+    ///
+    /// This is what makes replication EVENT-DRIVEN: every successful PUT /
+    /// DELETE / COPY / CompleteMultipartUpload publishes a fact here, which the
+    /// replication consumer (and webhook delivery) drain. DG-internal keys
+    /// (delta artifacts, dir markers, config-sync) are filtered so they never
+    /// generate replication work. Noops silently when no config DB is present
+    /// (open-mode dev) — same contract as the form-POST path.
+    async fn emit_object_event(
+        &self,
+        kind: crate::event_outbox::EventKind,
+        bucket: &str,
+        key: &str,
+        payload: serde_json::Value,
+    ) {
+        if !crate::replication::event_consumer::is_user_object_key(key) {
+            return;
+        }
+        crate::api::handlers::object_helpers::enqueue_object_event(
+            &self.state,
+            crate::event_outbox::NewEvent::new(
+                kind,
+                bucket,
+                key,
+                crate::event_outbox::EventSource::S3Api,
+                crate::replication::current_unix_seconds(),
+                payload,
+            ),
+        )
+        .await;
+    }
 }
 
 #[async_trait::async_trait]
@@ -630,7 +662,19 @@ impl s3s::S3 for DeltaGliderS3Service {
             .delete(&input.bucket, &input.key)
             .await
         {
-            Ok(()) | Err(crate::deltaglider::EngineError::NotFound(_)) => {
+            // Only a REAL delete (Ok) emits an event — a NotFound deleted
+            // nothing, so there's nothing for replication to mirror.
+            Ok(()) => {
+                self.emit_object_event(
+                    crate::event_outbox::EventKind::ObjectDeleted,
+                    &input.bucket,
+                    &input.key,
+                    serde_json::json!({}),
+                )
+                .await;
+                Ok(s3s::S3Response::new(s3s::dto::DeleteObjectOutput::default()))
+            }
+            Err(crate::deltaglider::EngineError::NotFound(_)) => {
                 Ok(s3s::S3Response::new(s3s::dto::DeleteObjectOutput::default()))
             }
             Err(e) => Err(engine_error_to_s3s(e)),
@@ -646,10 +690,33 @@ impl s3s::S3 for DeltaGliderS3Service {
         let quiet = input.delete.quiet.unwrap_or(false);
         let mut deleted = Vec::new();
         let mut errors = Vec::new();
+        // Collect ObjectDeleted events for keys that were ACTUALLY deleted
+        // (Ok, not NotFound), filtered to user objects, and batch-insert once
+        // after the loop (single DB lock).
+        let mut delete_events: Vec<crate::event_outbox::NewEvent> = Vec::new();
         for obj in input.delete.objects {
             let key = obj.key.trim_start_matches('/').to_string();
             match self.state.engine.load().delete(&input.bucket, &key).await {
-                Ok(()) | Err(crate::deltaglider::EngineError::NotFound(_)) => {
+                Ok(()) => {
+                    if crate::replication::event_consumer::is_user_object_key(&key) {
+                        delete_events.push(crate::event_outbox::NewEvent::new(
+                            crate::event_outbox::EventKind::ObjectDeleted,
+                            input.bucket.clone(),
+                            key.clone(),
+                            crate::event_outbox::EventSource::S3Api,
+                            crate::replication::current_unix_seconds(),
+                            serde_json::json!({}),
+                        ));
+                    }
+                    if !quiet {
+                        deleted.push(s3s::dto::DeletedObject {
+                            key: Some(obj.key),
+                            version_id: obj.version_id,
+                            ..Default::default()
+                        });
+                    }
+                }
+                Err(crate::deltaglider::EngineError::NotFound(_)) => {
                     if !quiet {
                         deleted.push(s3s::dto::DeletedObject {
                             key: Some(obj.key),
@@ -669,6 +736,8 @@ impl s3s::S3 for DeltaGliderS3Service {
                 }
             }
         }
+        crate::api::handlers::object_helpers::enqueue_object_events(&self.state, &delete_events)
+            .await;
         Ok(s3s::S3Response::new(s3s::dto::DeleteObjectsOutput {
             deleted: (!deleted.is_empty()).then_some(deleted),
             errors: (!errors.is_empty()).then_some(errors),
@@ -732,6 +801,17 @@ impl s3s::S3 for DeltaGliderS3Service {
             )
             .await
             .map_err(engine_error_to_s3s)?;
+        self.emit_object_event(
+            crate::event_outbox::EventKind::ObjectCreated,
+            &input.bucket,
+            &input.key,
+            serde_json::json!({
+                "content_length": data.len(),
+                "storage_type": result.metadata.storage_info.label(),
+                "etag": result.metadata.etag(),
+            }),
+        )
+        .await;
         let mut resp = s3s::S3Response::new(s3s::dto::PutObjectOutput {
             e_tag: Some(parse_s3s_etag(&result.metadata.etag())?),
             ..Default::default()
@@ -808,6 +888,19 @@ impl s3s::S3 for DeltaGliderS3Service {
             )
             .await
             .map_err(engine_error_to_s3s)?;
+        // A copy creates a new object at the destination — emit ObjectCreated
+        // for the dest key. Routing decides whether a replication rule cares.
+        self.emit_object_event(
+            crate::event_outbox::EventKind::ObjectCreated,
+            &input.bucket,
+            &input.key,
+            serde_json::json!({
+                "content_length": data.len(),
+                "storage_type": result.metadata.storage_info.label(),
+                "etag": result.metadata.etag(),
+            }),
+        )
+        .await;
         Ok(s3s::S3Response::new(s3s::dto::CopyObjectOutput {
             copy_object_result: Some(s3s::dto::CopyObjectResult {
                 e_tag: Some(parse_s3s_etag(&result.metadata.etag())?),
@@ -1042,6 +1135,19 @@ impl s3s::S3 for DeltaGliderS3Service {
             }
         };
         self.state.multipart.finish_upload(&input.upload_id);
+        // A completed multipart upload created the final object — emit
+        // ObjectCreated before `input.bucket`/`input.key` are moved into the
+        // response.
+        self.emit_object_event(
+            crate::event_outbox::EventKind::ObjectCreated,
+            &input.bucket,
+            &input.key,
+            serde_json::json!({
+                "etag": multipart_etag,
+                "storage_type": store_meta.as_ref().map(|m| m.storage_info.label()),
+            }),
+        )
+        .await;
         let location = format!("/{}/{}", input.bucket, input.key);
         let mut resp = s3s::S3Response::new(s3s::dto::CompleteMultipartUploadOutput {
             bucket: Some(input.bucket),

--- a/tests/admin_config_test.rs
+++ b/tests/admin_config_test.rs
@@ -666,6 +666,82 @@ async fn test_config_apply_preserves_sigv4_secret_on_redacted_roundtrip() {
     assert_eq!(cfg["access_key_id"], "PRESERVEKEY");
 }
 
+/// Document-level apply must preserve webhook header secrets across a redacted
+/// export → apply round-trip — the same contract as SigV4 above, for the
+/// `event_delivery.webhook_headers` values masked by `redact_all_secrets`.
+/// Without the `preserve_event_delivery_secrets` call in `preserve_runtime_secrets`,
+/// "Export YAML → Import YAML" (or any GitOps round-trip) would persist the
+/// literal sentinel as the bearer token.
+#[tokio::test]
+async fn test_config_apply_preserves_webhook_header_secret_on_redacted_roundtrip() {
+    let server = TestServer::builder()
+        .auth("WHDOCKEY", "WHDOCSECRET")
+        .yaml_config()
+        .build()
+        .await;
+    let admin = admin_http_client(&server.endpoint()).await;
+
+    // Seed a webhook with a secret header via the section API.
+    let put = admin
+        .put(format!(
+            "{}/_/api/admin/config/section/advanced",
+            server.endpoint()
+        ))
+        .json(&json!({
+            "event_delivery": {
+                "enabled": true,
+                "webhook_urls": ["https://hooks.example.com/dg"],
+                "webhook_headers": { "Authorization": "Bearer WEBHOOK-DOC-TOKEN" }
+            }
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(put.status(), StatusCode::OK, "seed PUT must succeed");
+
+    // Export the full document — the header value must be redacted.
+    let exported = admin
+        .get(format!("{}/_/api/admin/config/export", server.endpoint()))
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+    assert!(
+        !exported.contains("WEBHOOK-DOC-TOKEN"),
+        "precondition: export must redact the webhook header secret, got:\n{exported}"
+    );
+    assert!(
+        exported.contains("__redacted__"),
+        "precondition: export should carry the redaction sentinel"
+    );
+
+    // Apply the exported-as-is YAML (the Export→Import round-trip).
+    let resp = admin
+        .post(format!("{}/_/api/admin/config/apply", server.endpoint()))
+        .json(&json!({ "yaml": exported }))
+        .send()
+        .await
+        .unwrap();
+    let status = resp.status();
+    let text = resp.text().await.unwrap();
+    assert_eq!(status, StatusCode::OK, "apply should succeed, body: {text}");
+
+    // The real token must survive in the persisted config (NOT clobbered with
+    // "__redacted__"). Re-export and confirm the sentinel is still a *mask* over
+    // a real value by checking the persisted YAML on disk holds the real token.
+    let persisted = std::fs::read_to_string(server.config_path()).expect("read persisted config");
+    assert!(
+        persisted.contains("Bearer WEBHOOK-DOC-TOKEN"),
+        "real webhook token must survive document apply, persisted config:\n{persisted}"
+    );
+    assert!(
+        !persisted.contains("__redacted__"),
+        "persisted config must NOT contain the sentinel (it would mean the token was clobbered)"
+    );
+}
+
 // ═══════════════════════════════════════════════════
 // Phase 1 — audit-driven correctness regressions
 // ═══════════════════════════════════════════════════

--- a/tests/admin_section_test.rs
+++ b/tests/admin_section_test.rs
@@ -1122,3 +1122,107 @@ async fn section_put_storage_buckets_are_merged_not_replaced() {
 // future-proofing is the value of the shared helpers; the asymmetric
 // warning isn't reachable through the normal section-merge flow today.
 // -------------------------------------------------------------------------
+
+/// Webhook header secrets survive the GUI round-trip: GET masks header VALUES to
+/// the redaction sentinel (keeping keys), PUT with the sentinel preserves the
+/// real token, PUT with a real value overwrites, and PUT with `null` deletes the
+/// header. This is the secret-safety contract behind the Webhook delivery panel.
+#[tokio::test]
+async fn section_webhook_headers_secret_roundtrip() {
+    const SENTINEL: &str = "__redacted__";
+    let server = TestServer::builder()
+        .auth("WHSEC1", "WHSECRET1")
+        .yaml_config()
+        .build()
+        .await;
+    let admin = admin_http_client(&server.endpoint()).await;
+    let url = format!("{}/_/api/admin/config/section/advanced", server.endpoint());
+
+    // 1. Seed a webhook with a secret header.
+    let resp = admin
+        .put(&url)
+        .json(&json!({
+            "event_delivery": {
+                "enabled": true,
+                "webhook_urls": ["https://hooks.example.com/in"],
+                "webhook_headers": { "Authorization": "Bearer real-token-123" }
+            }
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK, "seed PUT must succeed");
+
+    // 2. GET must MASK the value but KEEP the key.
+    let resp = admin.get(&url).send().await.unwrap();
+    let body: serde_json::Value = resp.json().await.unwrap();
+    let hdrs = &body["event_delivery"]["webhook_headers"];
+    assert_eq!(
+        hdrs["Authorization"].as_str(),
+        Some(SENTINEL),
+        "GET must redact the header value, got: {body}"
+    );
+
+    // 3. PUT back the masked value (simulating an unedited round-trip) → the real
+    //    token must be PRESERVED, not overwritten with the sentinel.
+    let resp = admin
+        .put(&url)
+        .json(&json!({
+            "event_delivery": {
+                "webhook_headers": { "Authorization": SENTINEL }
+            }
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    // Prove the runtime still has the real token: the field-level config GET
+    // (which does NOT redact event_delivery the same way) round-trips it... but
+    // since GET always masks, assert preservation indirectly by re-PUTting the
+    // sentinel a second time and confirming the webhook stays active (a clobbered
+    // token would still be a non-empty string, so instead delete + re-read).
+
+    // 4. PUT a REAL new value → overwrites.
+    let resp = admin
+        .put(&url)
+        .json(&json!({
+            "event_delivery": {
+                "webhook_headers": { "Authorization": "Bearer rotated-456" }
+            }
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    // GET still masks, so we can't read the value back; assert the key persists.
+    let resp = admin.get(&url).send().await.unwrap();
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(
+        body["event_delivery"]["webhook_headers"]["Authorization"].as_str(),
+        Some(SENTINEL),
+        "rotated header key must persist (value masked)"
+    );
+
+    // 5. PUT `null` for the header → DELETE it (RFC 7396).
+    let resp = admin
+        .put(&url)
+        .json(&json!({
+            "event_delivery": {
+                "webhook_headers": { "Authorization": null }
+            }
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let resp = admin.get(&url).send().await.unwrap();
+    let body: serde_json::Value = resp.json().await.unwrap();
+    let hdrs = &body["event_delivery"]["webhook_headers"];
+    assert!(
+        hdrs.get("Authorization").is_none()
+            || hdrs.is_null()
+            || hdrs.as_object().map(|m| m.is_empty()).unwrap_or(true),
+        "Authorization header must be deleted, got: {body}"
+    );
+}

--- a/tests/admin_section_test.rs
+++ b/tests/admin_section_test.rs
@@ -1129,7 +1129,9 @@ async fn section_put_storage_buckets_are_merged_not_replaced() {
 /// header. This is the secret-safety contract behind the Webhook delivery panel.
 #[tokio::test]
 async fn section_webhook_headers_secret_roundtrip() {
-    const SENTINEL: &str = "__redacted__";
+    // Reference the library constant so a Rust-side rename of the sentinel
+    // breaks this test immediately (instead of silently passing on a stale literal).
+    const SENTINEL: &str = deltaglider_proxy::config::REDACTED_SENTINEL;
     let server = TestServer::builder()
         .auth("WHSEC1", "WHSECRET1")
         .yaml_config()
@@ -1177,11 +1179,18 @@ async fn section_webhook_headers_secret_roundtrip() {
         .unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
 
-    // Prove the runtime still has the real token: the field-level config GET
-    // (which does NOT redact event_delivery the same way) round-trips it... but
-    // since GET always masks, assert preservation indirectly by re-PUTting the
-    // sentinel a second time and confirming the webhook stays active (a clobbered
-    // token would still be a non-empty string, so instead delete + re-read).
+    // Prove preservation: the persisted config on disk must still hold the REAL
+    // token, NOT the sentinel. (The GET always masks, so we read the persisted
+    // YAML directly — same technique as the document-apply preserve test.)
+    let persisted = std::fs::read_to_string(server.config_path()).expect("read persisted config");
+    assert!(
+        persisted.contains("Bearer real-token-123"),
+        "unedited sentinel round-trip must preserve the real token, persisted:\n{persisted}"
+    );
+    assert!(
+        !persisted.contains(SENTINEL),
+        "persisted config must not contain the sentinel (would mean the token was clobbered)"
+    );
 
     // 4. PUT a REAL new value → overwrites.
     let resp = admin

--- a/tests/recursive_delete_test.rs
+++ b/tests/recursive_delete_test.rs
@@ -28,14 +28,21 @@ async fn test_recursive_delete_paginates_and_deletes_all() {
     const N: usize = 1100;
     let bucket = server.bucket();
 
-    // Seed in batches via concurrent requests to keep the test quick.
+    // Seed concurrently to keep the test quick, but cap in-flight requests with
+    // a semaphore. Unbounded N-way fan-out opens N simultaneous TCP connections
+    // and exhausts the runner's file-descriptor limit ("Too many open files",
+    // Os code 24) on loaded CI hosts — bounding concurrency keeps open fds low
+    // while still pipelining the seed.
     let base = server.endpoint();
+    let sem = std::sync::Arc::new(tokio::sync::Semaphore::new(64));
     let put_handles: Vec<_> = (0..N)
         .map(|i| {
             let url = format!("{}/{}/toDelete/obj-{:05}.txt", base, bucket, i);
             let body = format!("payload-{}", i);
             let c = client.clone();
+            let sem = sem.clone();
             tokio::spawn(async move {
+                let _permit = sem.acquire().await.unwrap();
                 c.put(&url).body(body).send().await.unwrap();
             })
         })

--- a/tests/replication_test.rs
+++ b/tests/replication_test.rs
@@ -30,6 +30,26 @@ replication:
       batch_size: 100
 ";
 
+// Fast tick so the event-driven consumer (and reconcile scheduler) wake
+// quickly in tests. The consumer drains the outbox each tick.
+const EVENT_DRIVEN_RULE_YAML: &str = "
+replication:
+  enabled: true
+  tick_interval: \"5s\"
+  rules:
+    - name: ev-a-to-b
+      enabled: true
+      source:
+        bucket: ev-src
+        prefix: \"\"
+      destination:
+        bucket: ev-dst
+        prefix: \"\"
+      interval: \"24h\"
+      batch_size: 100
+      replicate_deletes: true
+";
+
 const PAUSED_RULE_YAML: &str = "
 replication:
   enabled: true
@@ -1184,5 +1204,88 @@ async fn test_replication_any_error_flips_status_to_failed() {
         status, "failed",
         "M1 REGRESSION: errors={} but status={} (must be 'failed' on any error). body={}",
         errors, status, body
+    );
+}
+
+/// Event-driven replication: PUTting an object to the source bucket emits an
+/// ObjectCreated event that the background consumer drains and replicates to
+/// the destination — WITHOUT any run-now trigger. Then deleting it propagates
+/// the delete (replicate_deletes: true). This is the core event-driven path.
+#[tokio::test]
+async fn test_event_driven_replication_copies_and_deletes() {
+    let server = TestServer::builder()
+        .auth("bootstrap_key", "bootstrap_secret")
+        .extra_yaml_storage_section(EVENT_DRIVEN_RULE_YAML)
+        .build()
+        .await;
+
+    let client = server.s3_client().await;
+    for b in ["ev-src", "ev-dst"] {
+        client.create_bucket().bucket(b).send().await.ok();
+    }
+
+    // PUT a single object to the source. No run-now: the write-path emits an
+    // event and the consumer (5s tick) should replicate it on its own.
+    client
+        .put_object()
+        .bucket("ev-src")
+        .key("evt/obj.txt")
+        .body(ByteStream::from(b"event-driven".to_vec()))
+        .send()
+        .await
+        .expect("put source object");
+
+    // Poll the destination for up to ~30s (several consumer ticks).
+    let mut replicated = false;
+    for _ in 0..30 {
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+        if let Ok(out) = client
+            .get_object()
+            .bucket("ev-dst")
+            .key("evt/obj.txt")
+            .send()
+            .await
+        {
+            let body = out.body.collect().await.unwrap().into_bytes();
+            if body.as_ref() == b"event-driven" {
+                replicated = true;
+                break;
+            }
+        }
+    }
+    assert!(
+        replicated,
+        "object should be replicated to ev-dst by the event consumer (no run-now)"
+    );
+
+    // Now DELETE the source object — the delete event should propagate.
+    client
+        .delete_object()
+        .bucket("ev-src")
+        .key("evt/obj.txt")
+        .send()
+        .await
+        .expect("delete source object");
+
+    let mut deleted = false;
+    for _ in 0..30 {
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+        match client
+            .get_object()
+            .bucket("ev-dst")
+            .key("evt/obj.txt")
+            .send()
+            .await
+        {
+            Err(_) => {
+                deleted = true;
+                break;
+            }
+            Ok(_) => continue,
+        }
+    }
+    assert!(
+        deleted,
+        "delete should propagate to ev-dst (replicate_deletes: true)"
     );
 }


### PR DESCRIPTION
## Event-driven replication

Converts replication from **pure-poll** (timer-based full list+diff every tick, scaling with bucket size) to **event-driven**: object mutations append to the durable `event_outbox`, a new consumer drains them in near-real time and fans each key out to matching rules. The per-rule `interval` reconcile is demoted to a slow **24h** self-healing safety net.

### Design (locked)
- **Pub/sub via a per-listener cursor** over the append-only outbox — webhook delivery and replication keep independent cursors, no shared-status contention.
- **Ordering by autoincrement `id`**, not wall-clock `occurred_at` (can tie/regress across instances).
- **Per-key compaction**: N events for one key collapse to one liveness verdict (last-event-wins) before acting.
- **Idempotency in ONE place** — the planner's `should_replicate` + a dest HEAD, shared with reconcile. No new per-(rule,key) sync table.
- **Watermark**: cursor advances only to the highest *contiguous* fully-handled id → at-least-once; reconcile backstops the rest.

### Safety hardening (from an adversarial review pass)
- Webhook pruner clamps its delete floor to the smallest **active** listener cursor — a stuck/disabled consumer no longer pins the floor forever, preventing unbounded outbox growth.
- Consumer cursor is seeded **after** the `enabled` gate, so a webhook-only deployment never creates a `replication` cursor that would pin the floor.
- `EventKind`↔liveness coupling guard test against silent replication drop on a variant rename.
- `owned_by_rule` delete-safety predicate extracted + exhaustively unit-tested.

### Tests
- 976 lib tests pass; fmt + clippy `-D warnings` clean.
- New integration test `test_event_driven_replication_copies_and_deletes` (PUT replicates with no run-now; source delete propagates) — full replication suite green with `DGP_REPLAY_WINDOW_SECS=0` (CI parity).
- Verified live on a prod-backup local instance: PUT→`ObjectCreated`, DELETE→`ObjectDeleted` land in the outbox; normal S3 ops unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
