### PR TITLE
Slack notifications connector (no-OAuth) on event delivery

### DIFF
--- a/deltaglider_proxy.example.yaml
+++ b/deltaglider_proxy.example.yaml
@@ -157,3 +157,19 @@ storage:
 #   #   delivered_retention: "24h"
 #   #   delivered_max_rows: 10000
 #   #   prune_batch: 100
+#   #
+#   #   # Slack notifications (no OAuth — paste a credential; works on private
+#   #   # instances, outbound HTTPS only). Set format: slack, then EITHER point
+#   #   # webhook_url at an Incoming Webhook, OR set slack_bot_token + slack_channel.
+#   #   format: slack
+#   #   # Incoming Webhook mode (simplest, single channel):
+#   #   webhook_url: "https://hooks.slack.com/services/T000/B000/XXXX"
+#   #   slack_username: "DeltaGlider"
+#   #   slack_icon_emoji: ":package:"
+#   #   # Bot-token mode (multi-channel + @mentions) — set these INSTEAD of webhook_url:
+#   #   # slack_bot_token: "xoxb-..."   # needs chat:write + chat:write.public scopes
+#   #   # slack_channel: "C0123456"     # channel id or #name
+#   #   # What gets posted:
+#   #   slack_notify_kinds: ["ObjectCreated"]   # add ObjectDeleted, etc.
+#   #   slack_include_globs: ["builds/**"]      # empty = all user objects
+#   #   slack_exclude_globs: ["**/*.tmp"]

--- a/deltaglider_proxy.example.yaml
+++ b/deltaglider_proxy.example.yaml
@@ -173,3 +173,16 @@ storage:
 #   #   slack_notify_kinds: ["ObjectCreated"]   # add ObjectDeleted, etc.
 #   #   slack_include_globs: ["builds/**"]      # empty = all user objects
 #   #   slack_exclude_globs: ["**/*.tmp"]
+#   #
+#   #   # Route different buckets/prefixes to different channels (bot-token mode
+#   #   # only — Incoming Webhook URLs are bound to one channel). An event posts
+#   #   # to EVERY route it matches. When slack_routes is set, slack_channel is
+#   #   # the fallback only for events that match no route.
+#   #   slack_routes:
+#   #     - name: "Releases → #ci"
+#   #       bucket: "releases"
+#   #       prefix_globs: ["builds/**"]   # empty = any key in the bucket
+#   #       channel: "C_CI"
+#   #     - name: "Audit → #security"
+#   #       bucket: "audit"
+#   #       channel: "C_SECURITY"

--- a/demo/s3-browser/ui/scripts/webhook-delivery-payload-regression-test.mjs
+++ b/demo/s3-browser/ui/scripts/webhook-delivery-payload-regression-test.mjs
@@ -18,7 +18,7 @@ async function loadModule(relPath, fileName) {
 }
 
 const url = await loadModule('../src/components/webhookDeliveryPayload.ts', 'webhookDeliveryPayload.ts');
-const { formFromWire, buildPayloadFromForm } = await import(url);
+const { formFromWire, buildPayloadFromForm, resolveSlackChannelsPreview } = await import(url);
 
 // Must equal REDACTED_SENTINEL in src/config.rs and the constant in
 // webhookDeliveryPayload.ts — the cross-language secret-mask sentinel.
@@ -315,6 +315,181 @@ function ed(res) {
   assert.equal(ed(res).slack_icon_emoji, ':package:');
   const empty = buildFromWire({ format: 'slack', webhook_urls: ['https://hooks.slack.com/services/T/B/x'] });
   assert.equal(ed(empty).slack_username, null, 'empty username → null (merge-patch clears)');
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Slack channel routing (per bucket / prefix → channel)
+// ─────────────────────────────────────────────────────────────────────────
+
+// ── route round-trip: wire → form → payload (bot-token mode) ──
+{
+  const res = buildFromWire({
+    format: 'slack',
+    slack_bot_token: SENTINEL,
+    slack_channel: '#default',
+    slack_routes: [
+      { name: 'CI', bucket: 'releases', prefix_globs: ['builds/**'], channel: '#ci' },
+      { bucket: 'audit', channel: '#audit' },
+    ],
+  });
+  assert.ok(res.ok, JSON.stringify(res.errors));
+  assert.deepEqual(
+    ed(res).slack_routes,
+    [
+      { channel: '#ci', name: 'CI', bucket: 'releases', prefix_globs: ['builds/**'] },
+      { channel: '#audit', bucket: 'audit' },
+    ],
+    'routes round-trip; empty name/globs omitted from the wire'
+  );
+  assert.equal(ed(res).slack_channel, '#default', 'fallback channel coexists with routes');
+}
+
+// ── empty-channel route is dropped (in-progress / blank) ──
+{
+  const res = buildFromWire(
+    { format: 'slack', slack_bot_token: SENTINEL, slack_channel: '#default' },
+    (f) => {
+      f.slackRoutes = [
+        { id: 'rt0', name: '', bucket: '', prefixGlobs: [], channel: '' }, // fully blank → dropped
+        { id: 'rt1', name: '', bucket: 'b', prefixGlobs: [], channel: '#real' },
+      ];
+    }
+  );
+  assert.ok(res.ok, JSON.stringify(res.errors));
+  assert.deepEqual(ed(res).slack_routes, [{ channel: '#real', bucket: 'b' }], 'blank route dropped, real route kept');
+}
+
+// ── a half-filled route (bucket but no channel) is an error, not silently dropped ──
+{
+  const res = buildFromWire(
+    { format: 'slack', slack_bot_token: SENTINEL, slack_channel: '#default' },
+    (f) => {
+      f.slackRoutes = [{ id: 'rt0', name: 'oops', bucket: 'b', prefixGlobs: [], channel: '' }];
+    }
+  );
+  assert.ok(!res.ok && res.errors.some((e) => /Route 1 needs a channel/.test(e)), 'half-filled route needs a channel');
+}
+
+// ── prefix_globs round-trip (trimmed, blanks dropped) ──
+{
+  const res = buildFromWire(
+    { format: 'slack', slack_bot_token: SENTINEL, slack_channel: '#default' },
+    (f) => {
+      f.slackRoutes = [
+        {
+          id: 'rt0',
+          name: '',
+          bucket: '',
+          prefixGlobs: [
+            { id: 'g0', glob: ' builds/** ' },
+            { id: 'g1', glob: '  ' }, // blank → dropped
+            { id: 'g2', glob: 'dist/*' },
+          ],
+          channel: '#ci',
+        },
+      ];
+    }
+  );
+  assert.ok(res.ok, JSON.stringify(res.errors));
+  assert.deepEqual(ed(res).slack_routes, [{ channel: '#ci', prefix_globs: ['builds/**', 'dist/*'] }], 'globs trimmed, blanks dropped');
+}
+
+// ── routes present but NOT bot-token mode → surfaced error ──
+{
+  const res = buildFromWire(
+    { format: 'slack', webhook_urls: ['https://hooks.slack.com/services/T/B/x'] },
+    (f) => {
+      f.enabled = true;
+      f.slackRoutes = [{ id: 'rt0', name: '', bucket: 'b', prefixGlobs: [], channel: '#ci' }];
+    }
+  );
+  assert.ok(!res.ok && res.errors.some((e) => /needs a bot token/i.test(e)), 'routing without bot token must error');
+}
+
+// ── routes + empty fallback channel coexist (allowed) ──
+{
+  const res = buildFromWire(
+    { format: 'slack', slack_bot_token: SENTINEL },
+    (f) => {
+      f.slackChannel = ''; // no fallback
+      f.slackRoutes = [{ id: 'rt0', name: '', bucket: '', prefixGlobs: [], channel: '#ci' }];
+    }
+  );
+  assert.ok(res.ok, `routes + empty fallback channel must be allowed, got ${JSON.stringify(res.errors)}`);
+  assert.equal(ed(res).slack_channel, null, 'empty fallback channel → null');
+  assert.deepEqual(ed(res).slack_routes, [{ channel: '#ci' }]);
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// resolveSlackChannelsPreview — mirrors src/slack_format.rs::resolve_channels
+// ─────────────────────────────────────────────────────────────────────────
+function route(name, bucket, globs, channel) {
+  return {
+    id: name + channel,
+    name: name ?? '',
+    bucket: bucket ?? '',
+    prefixGlobs: (globs ?? []).map((g, i) => ({ id: `g${i}`, glob: g })),
+    channel,
+  };
+}
+
+// ── no routes → fall back to the single channel ──
+{
+  const r = resolveSlackChannelsPreview([], '#default', 'b', 'k.zip');
+  assert.deepEqual(r.matches, []);
+  assert.ok(r.fellBackToChannel && r.fallbackChannel === '#default', 'falls back to single channel');
+}
+
+// ── bucket-scoped route matches its bucket, misses others ──
+{
+  const routes = [route('CI', 'releases', [], '#ci')];
+  const hit = resolveSlackChannelsPreview(routes, '#default', 'releases', 'x.zip');
+  assert.deepEqual(hit.matches.map((m) => m.channel), ['#ci'], 'bucket route matches');
+  const miss = resolveSlackChannelsPreview(routes, '#default', 'scratch', 'x.zip');
+  assert.ok(miss.matches.length === 0 && miss.fellBackToChannel, 'non-matching bucket falls back');
+}
+
+// ── fan-out: an event matches multiple routes → all channels (deduped) ──
+{
+  const routes = [
+    route('any', '', [], '#all'),
+    route('rel', 'releases', [], '#rel'),
+    route('dup', 'releases', [], '#all'), // same channel as first → deduped
+  ];
+  const r = resolveSlackChannelsPreview(routes, '#default', 'releases', 'x.zip');
+  assert.deepEqual(r.matches.map((m) => m.channel), ['#all', '#rel'], 'fan-out, deduped, order-preserving');
+  assert.ok(!r.fellBackToChannel, 'matched → no fallback');
+}
+
+// ── prefix-glob match (** crosses /, * within segment) ──
+{
+  const routes = [route('builds', '', ['builds/**'], '#ci')];
+  assert.deepEqual(
+    resolveSlackChannelsPreview(routes, '#default', 'any', 'builds/sub/app.zip').matches.map((m) => m.channel),
+    ['#ci'],
+    '** crosses slashes'
+  );
+  assert.ok(
+    resolveSlackChannelsPreview(routes, '#default', 'any', 'dist/app.zip').matches.length === 0,
+    'non-matching prefix falls back'
+  );
+  const seg = [route('seg', '', ['dist/*.zip'], '#seg')];
+  assert.deepEqual(
+    resolveSlackChannelsPreview(seg, '#default', 'any', 'dist/app.zip').matches.map((m) => m.channel),
+    ['#seg'],
+    '* matches within a segment'
+  );
+  assert.ok(
+    resolveSlackChannelsPreview(seg, '#default', 'any', 'dist/sub/app.zip').matches.length === 0,
+    '* does not cross a slash'
+  );
+}
+
+// ── no match + no fallback → no channel ──
+{
+  const routes = [route('rel', 'releases', [], '#rel')];
+  const r = resolveSlackChannelsPreview(routes, '', 'scratch', 'x');
+  assert.ok(r.matches.length === 0 && !r.fellBackToChannel, 'no match, no fallback → posted nowhere');
 }
 
 console.log('webhook-delivery-payload-regression-test: all assertions passed');

--- a/demo/s3-browser/ui/scripts/webhook-delivery-payload-regression-test.mjs
+++ b/demo/s3-browser/ui/scripts/webhook-delivery-payload-regression-test.mjs
@@ -178,4 +178,143 @@ function headers(res) {
   assert.ok(!h.ok && h.errors.some((e) => /invalid characters/i.test(e)), 'header name with space rejected');
 }
 
+// ─────────────────────────────────────────────────────────────────────────
+// Slack format
+// ─────────────────────────────────────────────────────────────────────────
+function ed(res) {
+  return res.body.event_delivery;
+}
+
+// ── format: raw still round-trips unchanged (no slack fields leak as set) ──
+{
+  const res = buildFromWire({ webhook_urls: ['https://hooks.example/in'] });
+  assert.ok(res.ok, JSON.stringify(res.errors));
+  assert.equal(ed(res).format, 'raw', 'format defaults to raw');
+  assert.equal(ed(res).slack_bot_token, null, 'no token in raw mode → null');
+  assert.deepEqual(ed(res).webhook_urls, ['https://hooks.example/in']);
+}
+
+// ── slack bot token: untouched (masked) → passes through as the sentinel ──
+{
+  const res = buildFromWire({
+    format: 'slack',
+    slack_bot_token: SENTINEL,
+    slack_channel: '#deploys',
+  });
+  assert.ok(res.ok, JSON.stringify(res.errors));
+  assert.equal(ed(res).format, 'slack');
+  assert.equal(ed(res).slack_bot_token, SENTINEL, 'untouched token → sentinel (server restores)');
+  assert.equal(ed(res).slack_channel, '#deploys');
+}
+
+// ── slack bot token: retyped → real value flows through ──
+{
+  const res = buildFromWire(
+    { format: 'slack', slack_bot_token: SENTINEL, slack_channel: '#deploys' },
+    (f) => {
+      f.slackBotToken = 'xoxb-NEW-TOKEN';
+      f.slackBotTokenMasked = false; // typing unmasks
+    }
+  );
+  assert.ok(res.ok, JSON.stringify(res.errors));
+  assert.equal(ed(res).slack_bot_token, 'xoxb-NEW-TOKEN', 'retyped token → real value');
+}
+
+// ── slack bot-token mode needs a channel ──
+{
+  const res = buildFromWire({
+    format: 'slack',
+    slack_bot_token: 'xoxb-real',
+    // no channel
+  });
+  assert.ok(!res.ok, 'bot token without channel must fail');
+  assert.ok(
+    res.errors.some((e) => /needs a channel/i.test(e)),
+    'error must mention the missing channel'
+  );
+}
+
+// ── a masked (untouched) token also counts as bot mode → still needs channel ──
+{
+  const res = buildFromWire({ format: 'slack', slack_bot_token: SENTINEL });
+  assert.ok(!res.ok && res.errors.some((e) => /needs a channel/i.test(e)), 'masked token = bot mode needs channel');
+}
+
+// ── slack webhook mode (no token), enabled, no URL → must fail ──
+{
+  const res = buildFromWire({ format: 'slack' }, (f) => {
+    f.enabled = true;
+    f.urlRows = [];
+  });
+  assert.ok(!res.ok, 'enabled webhook-mode Slack with no URL must fail');
+  assert.ok(
+    res.errors.some((e) => /webhook url/i.test(e) || /no slack incoming webhook/i.test(e)),
+    'error must mention the missing Slack webhook URL'
+  );
+}
+
+// ── slack webhook mode with a hooks.slack.com URL → ok ──
+{
+  const res = buildFromWire(
+    { format: 'slack', webhook_urls: ['https://hooks.slack.com/services/T/B/x'] },
+    (f) => {
+      f.enabled = true;
+    }
+  );
+  assert.ok(res.ok, JSON.stringify(res.errors));
+  assert.equal(ed(res).format, 'slack');
+  assert.equal(ed(res).slack_bot_token, null, 'webhook mode → no bot token');
+  assert.deepEqual(ed(res).webhook_urls, ['https://hooks.slack.com/services/T/B/x']);
+}
+
+// ── slack notify kinds: at least one must be selected ──
+{
+  const res = buildFromWire(
+    { format: 'slack', webhook_urls: ['https://hooks.slack.com/services/T/B/x'] },
+    (f) => {
+      f.slackNotifyKinds = [];
+    }
+  );
+  assert.ok(!res.ok && res.errors.some((e) => /at least one event kind/i.test(e)), 'no notify kinds must fail');
+}
+
+// ── slack notify kinds + globs round-trip; empty glob row rejected ──
+{
+  const ok = buildFromWire({
+    format: 'slack',
+    webhook_urls: ['https://hooks.slack.com/services/T/B/x'],
+    slack_notify_kinds: ['ObjectCreated', 'ObjectDeleted'],
+    slack_include_globs: ['releases/**'],
+    slack_exclude_globs: ['tmp/**'],
+  });
+  assert.ok(ok.ok, JSON.stringify(ok.errors));
+  assert.deepEqual(ed(ok).slack_notify_kinds, ['ObjectCreated', 'ObjectDeleted']);
+  assert.deepEqual(ed(ok).slack_include_globs, ['releases/**']);
+  assert.deepEqual(ed(ok).slack_exclude_globs, ['tmp/**']);
+
+  const bad = buildFromWire(
+    { format: 'slack', webhook_urls: ['https://hooks.slack.com/services/T/B/x'] },
+    (f) => {
+      f.slackIncludeRows = [{ id: 'g1', glob: '  ' }]; // blank → error
+    }
+  );
+  assert.ok(!bad.ok && bad.errors.some((e) => /prefix filter is empty/i.test(e)), 'blank glob row rejected');
+}
+
+// ── slack cosmetic fields (webhook mode) flow through; empty → null ──
+{
+  const res = buildFromWire(
+    { format: 'slack', webhook_urls: ['https://hooks.slack.com/services/T/B/x'] },
+    (f) => {
+      f.slackUsername = 'DeltaGlider';
+      f.slackIconEmoji = ':package:';
+    }
+  );
+  assert.ok(res.ok, JSON.stringify(res.errors));
+  assert.equal(ed(res).slack_username, 'DeltaGlider');
+  assert.equal(ed(res).slack_icon_emoji, ':package:');
+  const empty = buildFromWire({ format: 'slack', webhook_urls: ['https://hooks.slack.com/services/T/B/x'] });
+  assert.equal(ed(empty).slack_username, null, 'empty username → null (merge-patch clears)');
+}
+
 console.log('webhook-delivery-payload-regression-test: all assertions passed');

--- a/demo/s3-browser/ui/scripts/webhook-delivery-payload-regression-test.mjs
+++ b/demo/s3-browser/ui/scripts/webhook-delivery-payload-regression-test.mjs
@@ -445,8 +445,13 @@ function route(name, bucket, globs, channel) {
   const routes = [route('CI', 'releases', [], '#ci')];
   const hit = resolveSlackChannelsPreview(routes, '#default', 'releases', 'x.zip');
   assert.deepEqual(hit.matches.map((m) => m.channel), ['#ci'], 'bucket route matches');
+  // Routes EXIST but none match → backend posts NOWHERE (no fallback to the
+  // single channel once routes are configured). Preview must NOT claim fallback.
   const miss = resolveSlackChannelsPreview(routes, '#default', 'scratch', 'x.zip');
-  assert.ok(miss.matches.length === 0 && miss.fellBackToChannel, 'non-matching bucket falls back');
+  assert.ok(
+    miss.matches.length === 0 && !miss.fellBackToChannel,
+    'non-matching bucket with routes present → no channel (NOT fallback)'
+  );
 }
 
 // ── fan-out: an event matches multiple routes → all channels (deduped) ──
@@ -471,7 +476,7 @@ function route(name, bucket, globs, channel) {
   );
   assert.ok(
     resolveSlackChannelsPreview(routes, '#default', 'any', 'dist/app.zip').matches.length === 0,
-    'non-matching prefix falls back'
+    'non-matching prefix → no channel'
   );
   const seg = [route('seg', '', ['dist/*.zip'], '#seg')];
   assert.deepEqual(

--- a/demo/s3-browser/ui/src/ThemeProvider.tsx
+++ b/demo/s3-browser/ui/src/ThemeProvider.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type ReactNode } from 'react';
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
 import { darkColors, lightColors, ThemeContext } from './ThemeContext';
 
 export default function ThemeProvider({ children }: { children: ReactNode }) {
@@ -7,7 +7,10 @@ export default function ThemeProvider({ children }: { children: ReactNode }) {
     return saved ? saved === 'dark' : true;
   });
 
-  const toggleTheme = () => setIsDark(prev => !prev);
+  // Stable identity so the context value (and therefore every `useColors()` /
+  // `useTheme()` consumer — i.e. nearly the whole tree) only churns on an actual
+  // theme change, not on every ThemeProvider render.
+  const toggleTheme = useCallback(() => setIsDark((prev) => !prev), []);
   const colors = isDark ? darkColors : lightColors;
 
   useEffect(() => {
@@ -15,9 +18,7 @@ export default function ThemeProvider({ children }: { children: ReactNode }) {
     document.documentElement.setAttribute('data-theme', isDark ? 'dark' : 'light');
   }, [isDark]);
 
-  return (
-    <ThemeContext.Provider value={{ isDark, toggleTheme, colors }}>
-      {children}
-    </ThemeContext.Provider>
-  );
+  const value = useMemo(() => ({ isDark, toggleTheme, colors }), [isDark, toggleTheme, colors]);
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
 }

--- a/demo/s3-browser/ui/src/components/AdmissionPanel.tsx
+++ b/demo/s3-browser/ui/src/components/AdmissionPanel.tsx
@@ -23,15 +23,15 @@
  *      `ApplyDialog`, on confirm call `putSection`.
  *   4. Discard: revert the dirty state to the last-applied snapshot.
  */
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import { Button, Alert, Typography, Space, Modal } from 'antd';
 import {
   PlusOutlined,
   InfoCircleOutlined,
   ExclamationCircleOutlined,
 } from '@ant-design/icons';
-import type { AdmissionBlock, AdminConfig } from '../adminApi';
-import { getAdminConfig } from '../adminApi';
+import type { AdmissionBlock } from '../adminApi';
+import { useAdminConfig } from '../queries/config';
 import { useColors } from '../ThemeContext';
 import { useSectionEditor } from '../useSectionEditor';
 import AdmissionBlockList from './AdmissionBlockList';
@@ -58,7 +58,9 @@ export default function AdmissionPanel({
 }: Props) {
   const { BORDER, TEXT_MUTED } = useColors();
 
-  const [config, setConfig] = useState<AdminConfig | null>(null);
+  // Bucket-policies for the synthesised-blocks preview come from the
+  // cached config query (shared, invalidated by config mutations).
+  const { data: config } = useAdminConfig();
 
   // The shared editor handles the admission section (blocks[]).
   // Local state is `AdmissionBlock[]`; wire shape is
@@ -83,25 +85,6 @@ export default function AdmissionPanel({
     toPayload: (v) => ({ blocks: v }),
     noun: 'admission blocks',
   });
-
-  // We still need the bucket-policies for the synthesised-blocks
-  // preview — fetch them alongside, independently of the section editor.
-  useEffect(() => {
-    let cancelled = false;
-    void (async () => {
-      try {
-        const cfg = await getAdminConfig();
-        if (!cancelled) setConfig(cfg);
-      } catch (e) {
-        if (e instanceof Error && e.message.includes('401')) {
-          onSessionExpired?.();
-        }
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [onSessionExpired]);
 
   // Modal state: when the operator clicks Add or Edit, we set
   // `editing` to the index (or -1 for Add) and `editingBlock` to

--- a/demo/s3-browser/ui/src/components/AuthenticationPanel.tsx
+++ b/demo/s3-browser/ui/src/components/AuthenticationPanel.tsx
@@ -377,7 +377,7 @@ export default function AuthenticationPanel({ onSessionExpired }: Props) {
         <Text type="secondary" style={{ fontSize: 12 }}>No rules configured. Add allowed email patterns (e.g. *@company.com) and assign them to groups.</Text>
       ) : (
         <div style={{ display: 'flex', flexDirection: 'column', gap: 6, marginBottom: 16 }}>
-          {rules.map((rule, idx) => (
+          {rules.map((rule) => (
             <MappingRuleRow
               key={rule.id}
               rule={rule}
@@ -387,9 +387,14 @@ export default function AuthenticationPanel({ onSessionExpired }: Props) {
               disabled={rulesSaving}
               onUpdate={(req) => {
                 // Local edit only — no API call. Save button appears below.
-                const next = [...rules];
-                next[idx] = { ...next[idx], ...req as Partial<typeof rule> };
-                setRules(next);
+                // Key the update by the row's stable id, NOT the array index:
+                // an index write goes stale if the list ever reorders (the
+                // documented admin-editor bug class).
+                setRules((prev) =>
+                  prev.map((r) =>
+                    r.id === rule.id ? { ...r, ...(req as Partial<typeof rule>) } : r,
+                  ),
+                );
                 setRulesDirty(true);
               }}
               onDelete={async () => {

--- a/demo/s3-browser/ui/src/components/AuthenticationPanel.tsx
+++ b/demo/s3-browser/ui/src/components/AuthenticationPanel.tsx
@@ -2,11 +2,12 @@ import { useState, useEffect, useCallback } from 'react';
 import { Button, Typography, Input, Alert, Switch, Divider, Spin, message } from 'antd';
 import { PlusOutlined, SearchOutlined, CopyOutlined, SafetyOutlined, CheckCircleOutlined, CloseCircleOutlined, SyncOutlined } from '@ant-design/icons';
 import {
-  getAdminConfig, getAuthProviders, createAuthProvider, updateAuthProvider, deleteAuthProvider, testAuthProvider,
+  getAuthProviders, createAuthProvider, updateAuthProvider, deleteAuthProvider, testAuthProvider,
   getMappingRules, createMappingRule, updateMappingRule, deleteMappingRule,
   previewMapping, getExternalIdentities, syncMemberships, getGroups,
-  type AuthProvider, type IamMode, type MappingRule, type ExternalIdentity, type IamGroup, type ProviderTestResult,
+  type AuthProvider, type MappingRule, type ExternalIdentity, type IamGroup, type ProviderTestResult,
 } from '../adminApi';
+import { useAdminConfig } from '../queries/config';
 import { useColors } from '../ThemeContext';
 import { useFormLabelStyle } from './shared-styles';
 import IamSourceBanner from './IamSourceBanner';
@@ -26,19 +27,10 @@ export default function AuthenticationPanel({ onSessionExpired }: Props) {
   const [groups, setGroups] = useState<IamGroup[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
-  const [iamMode, setIamMode] = useState<IamMode | undefined>(undefined);
 
-  // Load IAM mode once for the source-of-truth banner.
-  useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      const cfg = await getAdminConfig();
-      if (!cancelled && cfg) setIamMode(cfg.iam_mode);
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
+  // IAM mode for the source-of-truth banner (cached react-query read).
+  const { data: cfg } = useAdminConfig();
+  const iamMode = cfg?.iam_mode;
 
   // Provider form state
   const [selectedProvider, setSelectedProvider] = useState<AuthProvider | null>(null);

--- a/demo/s3-browser/ui/src/components/BackendsPanel.tsx
+++ b/demo/s3-browser/ui/src/components/BackendsPanel.tsx
@@ -328,7 +328,7 @@ export default function BackendsPanel({ onSessionExpired }: Props) {
         {showForm && (
           <div style={cardStyle}>
             <SectionHeader icon={<PlusOutlined />} title="New Backend" />
-            <div style={{ marginTop: 16 }}>
+            <div>
               <FormField label="Name" yamlPath="storage.backends[].name">
                 <Input value={formName} onChange={(e) => setFormName(e.target.value)} placeholder="e.g. local, hetzner, aws-prod" style={{ ...inputRadius, fontFamily: 'var(--font-mono)', fontSize: 13 }} />
               </FormField>
@@ -384,7 +384,7 @@ export default function BackendsPanel({ onSessionExpired }: Props) {
             title="Bucket policy routing"
             description="Per-bucket routing, compression, aliases, quotas, and public read live in the Buckets page."
           />
-          <div style={{ marginTop: 12, display: 'grid', gridTemplateColumns: 'repeat(4, minmax(0, 1fr))', gap: 8 }}>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, minmax(0, 1fr))', gap: 8 }}>
             {[
               ['Policies', bucketPolicyEntries.length, 'custom bucket rows'],
               ['Routed', routedPolicies.length, 'non-default backend'],

--- a/demo/s3-browser/ui/src/components/BackendsPanel.tsx
+++ b/demo/s3-browser/ui/src/components/BackendsPanel.tsx
@@ -3,8 +3,9 @@ import { useQueryClient } from '@tanstack/react-query';
 import { qk } from '../queries/keys';
 import { Button, Input, Radio, Switch, Typography, Space, Alert, Spin } from 'antd';
 import { PlusOutlined, DeleteOutlined, DatabaseOutlined, CloudOutlined, CheckCircleOutlined, ApiOutlined, FolderOutlined } from '@ant-design/icons';
-import type { BackendInfo, CreateBackendRequest, AdminConfig } from '../adminApi';
-import { getBackends, createBackend, deleteBackend, testS3Connection, getAdminConfig, updateAdminConfig, putSection } from '../adminApi';
+import type { BackendInfo, CreateBackendRequest } from '../adminApi';
+import { getBackends, createBackend, deleteBackend, testS3Connection, updateAdminConfig, putSection } from '../adminApi';
+import { useAdminConfig } from '../queries/config';
 import { useColors } from '../ThemeContext';
 import { useNavigation } from '../NavigationContext';
 import { useCardStyles } from './shared-styles';
@@ -29,7 +30,9 @@ export default function BackendsPanel({ onSessionExpired }: Props) {
 
   const [backends, setBackends] = useState<BackendInfo[]>([]);
   const [defaultBackend, setDefaultBackend] = useState<string | null>(null);
-  const [config, setConfig] = useState<AdminConfig | null>(null);
+  // Config is read from the shared cache; mutations below invalidate
+  // `qk.config()` (via refresh()) so this stays fresh for all readers.
+  const { data: config } = useAdminConfig();
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -52,17 +55,13 @@ export default function BackendsPanel({ onSessionExpired }: Props) {
 
   const refresh = async () => {
     try {
-      const [data, cfg] = await Promise.all([
-        getBackends(),
-        getAdminConfig(),
-      ]);
+      const data = await getBackends();
       setBackends(data.backends);
       setDefaultBackend(data.default_backend);
-      setConfig(cfg);
       setError(null);
-      // Invalidate the shared cache so any other panel reading
-      // backends/config (e.g. CredentialsModePanel, BucketsPanel)
-      // will refetch the freshly-saved state on its next mount.
+      // Invalidate the shared cache so any panel reading backends/config
+      // (this panel's own `useAdminConfig()`, CredentialsModePanel,
+      // BucketsPanel, …) refetches the freshly-saved state.
       qc.invalidateQueries({ queryKey: qk.backends.list() });
       qc.invalidateQueries({ queryKey: qk.config() });
     } catch (e) {

--- a/demo/s3-browser/ui/src/components/BucketsPanel.tsx
+++ b/demo/s3-browser/ui/src/components/BucketsPanel.tsx
@@ -36,7 +36,8 @@ import {
   PlusOutlined,
 } from '@ant-design/icons';
 import type { AdminConfig, BackendInfo } from '../adminApi';
-import { getAdminConfig, getBackends } from '../adminApi';
+import { getBackends } from '../adminApi';
+import { useAdminConfig } from '../queries/config';
 import { listBuckets } from '../s3client';
 import { useCardStyles } from './shared-styles';
 import SectionHeader from './SectionHeader';
@@ -96,35 +97,30 @@ export default function BucketsPanel({ onSessionExpired }: Props) {
     },
   });
 
-  const [backends, setBackends] = useState<BackendInfo[]>([]);
-  const [defaultBackend, setDefaultBackend] = useState<string | null>(null);
+  // Config (backends + default backend) comes from the shared cache.
+  const { data: cfg } = useAdminConfig();
+  // /api/admin/backends is the fallback when the config response doesn't
+  // carry a `backends` array (legacy shapes); available buckets come from
+  // the S3 list endpoint. Neither is part of the storage section body, so
+  // they're side-loaded independently of the section editor.
+  const [fallbackBackends, setFallbackBackends] = useState<BackendInfo[]>([]);
   const [availableBuckets, setAvailableBuckets] = useState<string[]>([]);
 
-  // Side-loaded data (backends, default backend, available buckets) is
-  // NOT part of the storage section body — fetch it independently. The
-  // section editor owns the row-editing shape + apply pipeline.
+  // getAdminConfig resolves to `null` on a 401; surface as session-expiry.
+  useEffect(() => {
+    if (cfg === null) onSessionExpired?.();
+  }, [cfg, onSessionExpired]);
+
   useEffect(() => {
     let cancelled = false;
     void (async () => {
       try {
-        const [cfg, bs, realBuckets] = await Promise.all([
-          getAdminConfig(),
+        const [bs, realBuckets] = await Promise.all([
           getBackends().then((r) => r.backends).catch(() => [] as BackendInfo[]),
           listBuckets().catch(() => [] as Array<{ name: string }>),
         ]);
         if (cancelled) return;
-        if (!cfg) {
-          onSessionExpired?.();
-          return;
-        }
-        // Prefer the /api/admin/config response's `backends` array —
-        // it synthesises a "default" entry on the singleton-backend
-        // path, so the per-bucket encryption badge works uniformly
-        // regardless of YAML shape. Fall back to /api/admin/backends
-        // when the primary endpoint doesn't carry backends (legacy
-        // response shapes).
-        setBackends(cfg.backends && cfg.backends.length > 0 ? cfg.backends : bs);
-        setDefaultBackend(cfg.default_backend ?? null);
+        setFallbackBackends(bs);
         setAvailableBuckets(realBuckets.map((b) => b.name));
       } catch (e) {
         if (cancelled) return;
@@ -135,6 +131,15 @@ export default function BucketsPanel({ onSessionExpired }: Props) {
       cancelled = true;
     };
   }, [onSessionExpired]);
+
+  // Prefer the /api/admin/config response's `backends` array — it
+  // synthesises a "default" entry on the singleton-backend path, so the
+  // per-bucket encryption badge works uniformly regardless of YAML shape.
+  // Fall back to /api/admin/backends when the primary endpoint doesn't
+  // carry backends (legacy response shapes).
+  const backends =
+    cfg?.backends && cfg.backends.length > 0 ? cfg.backends : fallbackBackends;
+  const defaultBackend = cfg?.default_backend ?? null;
 
   // Guarded apply: run the client-side duplicate-name check first and
   // surface the error, otherwise delegate to the section editor's

--- a/demo/s3-browser/ui/src/components/CredentialsModePanel.tsx
+++ b/demo/s3-browser/ui/src/components/CredentialsModePanel.tsx
@@ -229,7 +229,7 @@ export default function CredentialsModePanel({ onSessionExpired }: Props) {
           title="IAM mode"
           description="Who owns the user directory: this admin GUI + DB, or your YAML config?"
         />
-        <div style={{ marginTop: 16 }}>
+        <div>
           <Radio.Group
             value={form.iam_mode ?? 'gui'}
             onChange={(e) => setIamMode(e.target.value as IamMode)}
@@ -284,7 +284,7 @@ export default function CredentialsModePanel({ onSessionExpired }: Props) {
           title="S3 authentication mode"
           description="Whether clients must sign their requests with SigV4."
         />
-        <div style={{ marginTop: 16 }}>
+        <div>
           <Radio.Group
             value={authMode}
             onChange={(e) => setAuthMode(e.target.value as AuthMode)}
@@ -326,7 +326,7 @@ export default function CredentialsModePanel({ onSessionExpired }: Props) {
           title="Bootstrap SigV4 credentials"
           description="Used before any IAM users exist, and by legacy scripted clients. Not the same as the admin GUI password."
         />
-        <div style={{ marginTop: 16, display: 'flex', flexDirection: 'column', gap: 12 }}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
           <FormField
             label="Access key ID"
             yamlPath="access.access_key_id"

--- a/demo/s3-browser/ui/src/components/FormField.tsx
+++ b/demo/s3-browser/ui/src/components/FormField.tsx
@@ -11,10 +11,9 @@
  * ## Anatomy
  *
  * ```
- *  ┌── Label — Plain English name (not YAML key)
- *  │     YAML path • example chip • example chip
+ *  ┌── Label — Plain English name (not YAML key)  `yaml.path` (code chip)
  *  │     [       input (passed as children)       ]
- *  │     Help text below the input — one sentence.
+ *  │     Help text below the input — one sentence. • example chip
  *  └──
  *         ↑
  *    Amber left bar when `overrideActive` is true.
@@ -89,20 +88,22 @@ export default function FormField({
   children,
   style,
 }: FormFieldProps) {
-  const { TEXT_PRIMARY: TEXT, TEXT_MUTED, BG_CARD } = useColors();
+  const { TEXT_PRIMARY: TEXT, TEXT_MUTED, TEXT_FAINT, BG_CARD, BORDER } = useColors();
   const barColour = overrideColour || '#d18616'; // amber — matches §2.6 "override" indicator
+  // Tight groups, air between: the label→input→help unit hugs together; the
+  // BIG gap lives at the bottom of the group so each field reads as one chunk.
   const containerStyle: CSSProperties = {
     position: 'relative',
-    paddingLeft: overrideActive ? 10 : 0,
-    marginBottom: 20,
+    paddingLeft: overrideActive ? 12 : 0,
+    marginBottom: 32,
     transition: 'padding-left 120ms ease',
     ...style,
   };
   const barStyle: CSSProperties = {
     position: 'absolute',
     left: 0,
-    top: 2,
-    bottom: 2,
+    top: 0,
+    bottom: 0,
     width: 3,
     borderRadius: 3,
     background: barColour,
@@ -110,30 +111,43 @@ export default function FormField({
   };
 
   return (
-    <div style={containerStyle}>
+    <div className="dg-field" style={containerStyle}>
       <div style={barStyle} aria-hidden="true" />
-      {/* Label row: plain-English name, YAML path, owner badge */}
+      {/* Label row: plain-English name + the YAML path as a code chip on the
+          side. The chip is hidden until the field is hovered/focused (see
+          `.dg-field .dg-yaml-path` in theme.css) so the bold label is the only
+          thing competing for the eye at rest. */}
       <div
         style={{
           display: 'flex',
           alignItems: 'center',
           gap: 8,
-          marginBottom: 4,
+          marginBottom: 6,
           flexWrap: 'wrap',
         }}
       >
-        <span style={{ color: TEXT, fontSize: 13, fontWeight: 600 }}>{label}</span>
+        <span
+          style={{ color: TEXT, fontSize: 13.5, fontWeight: 600, letterSpacing: '-0.005em' }}
+        >
+          {label}
+        </span>
         {yamlPath && (
-          <span
+          <code
+            className="dg-yaml-path"
             style={{
-              color: TEXT_MUTED,
-              fontSize: 11,
               fontFamily: 'var(--font-mono)',
+              fontSize: 11,
+              color: TEXT_FAINT,
+              background: BG_CARD,
+              border: `1px solid ${BORDER}`,
+              borderRadius: 4,
+              padding: '1px 6px',
+              lineHeight: '18px',
             }}
             title="YAML path for this field"
           >
             {yamlPath}
-          </span>
+          </code>
         )}
         {ownerBadge && (
           <Tag
@@ -151,15 +165,17 @@ export default function FormField({
           </Tag>
         )}
       </div>
-      {/* Input */}
+      {/* Input — hugs the label above it */}
       <div>{children}</div>
-      {/* Under-input row: help text and example chips */}
+      {/* Help text — clearly subordinate: smaller, fainter, tight line-height.
+          Example chips share this row. */}
       {(helpText || defaultPlaceholder || (examples && examples.length > 0)) && (
         <div
           style={{
-            marginTop: 4,
-            fontSize: 11,
+            marginTop: 6,
+            fontSize: 12.5,
             color: TEXT_MUTED,
+            lineHeight: 1.4,
             display: 'flex',
             flexWrap: 'wrap',
             gap: 8,
@@ -171,8 +187,8 @@ export default function FormField({
             <span
               style={{
                 fontFamily: 'var(--font-mono)',
-                fontSize: 10,
-                opacity: 0.8,
+                fontSize: 11,
+                color: TEXT_FAINT,
               }}
               title="Runtime default when this field is omitted"
             >
@@ -180,13 +196,7 @@ export default function FormField({
             </span>
           )}
           {examples && examples.length > 0 && (
-            <span
-              style={{
-                display: 'inline-flex',
-                gap: 4,
-                flexWrap: 'wrap',
-              }}
-            >
+            <span style={{ display: 'inline-flex', gap: 4, flexWrap: 'wrap' }}>
               {examples.map((ex, i) => (
                 <button
                   key={i}
@@ -201,7 +211,7 @@ export default function FormField({
                     cursor: onExampleClick ? 'pointer' : 'default',
                     color: TEXT_MUTED,
                     fontFamily: 'var(--font-mono)',
-                    fontSize: 10,
+                    fontSize: 11,
                   }}
                   title={onExampleClick ? `Use "${ex}" as the value` : `Example value "${ex}"`}
                 >

--- a/demo/s3-browser/ui/src/components/GroupsPanel.tsx
+++ b/demo/s3-browser/ui/src/components/GroupsPanel.tsx
@@ -119,6 +119,7 @@ export default function GroupsPanel({ onSessionExpired, onSavingChange, initialG
 
   const detail = creating ? (
     <GroupForm
+      key="new"
       group={null}
       users={users}
       onSaved={handleSaved}
@@ -250,31 +251,24 @@ function GroupForm({ group, users, onSaved, onDeleted, onCancel, onSavingChange 
   const isEdit = group !== null;
   const { inputRadius } = useCardStyles();
 
-  const [name, setName] = useState('');
-  const [description, setDescription] = useState('');
-  const [permissions, setPermissions] = useState<PermissionRow[]>([]);
-  const [memberIds, setMemberIds] = useState<Set<number>>(new Set());
+  // Initialize from `group` once. The edit form is remounted with
+  // `key={selectedGroup.id}` (see render site), and the create form mounts
+  // fresh — so a keyed remount resets all state from these initializers. No
+  // prop→state sync effect needed (it was a redundant mirror of the prop).
+  const [name, setName] = useState(() => group?.name ?? '');
+  const [description, setDescription] = useState(() => group?.description ?? '');
+  const [permissions, setPermissions] = useState<PermissionRow[]>(() =>
+    group ? permissionsToRows(group.permissions) : [{ effect: 'Allow', actions: [], resources: '' }],
+  );
+  const [memberIds, setMemberIds] = useState<Set<number>>(
+    () => new Set(group?.member_ids ?? []),
+  );
   const [saving, setSavingState] = useState(false);
   const [deleting, setDeletingState] = useState(false);
   const [error, setError] = useState('');
 
   const setSaving = (v: boolean) => { setSavingState(v); onSavingChange?.(v); };
   const setDeleting = (v: boolean) => { setDeletingState(v); onSavingChange?.(v); };
-
-  useEffect(() => {
-    if (group) {
-      setName(group.name);
-      setDescription(group.description);
-      setPermissions(permissionsToRows(group.permissions));
-      setMemberIds(new Set(group.member_ids));
-    } else {
-      setName('');
-      setDescription('');
-      setPermissions([{ effect: 'Allow', actions: [], resources: '' }]);
-      setMemberIds(new Set());
-    }
-    setError('');
-  }, [group]);
 
   const handleSave = async () => {
     if (!name.trim()) { setError('Name is required'); return; }

--- a/demo/s3-browser/ui/src/components/GroupsPanel.tsx
+++ b/demo/s3-browser/ui/src/components/GroupsPanel.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect, useCallback } from 'react';
 import { Button, Typography, Alert, Input, Divider, Checkbox } from 'antd';
 import { PlusOutlined, FolderOutlined, DeleteOutlined, CopyOutlined } from '@ant-design/icons';
-import type { IamGroup, IamMode, IamUser } from '../adminApi';
-import { getAdminConfig, getGroups, createGroup, updateGroup, deleteGroup, addGroupMember, removeGroupMember, getUsers, cloneGroup } from '../adminApi';
+import type { IamGroup, IamUser } from '../adminApi';
+import { getGroups, createGroup, updateGroup, deleteGroup, addGroupMember, removeGroupMember, getUsers, cloneGroup } from '../adminApi';
+import { useAdminConfig } from '../queries/config';
 import { useCardStyles } from './shared-styles';
 import FormLabel from './FormLabel';
 import { useColors } from '../ThemeContext';
@@ -30,19 +31,10 @@ export default function GroupsPanel({ onSessionExpired, onSavingChange, initialG
   const [selectedId, setSelectedId] = useState<number | null>(initialGroupId ?? null);
   const [creating, setCreating] = useState(false);
   const [search, setSearch] = useState('');
-  const [iamMode, setIamMode] = useState<IamMode | undefined>(undefined);
 
-  // Load IAM mode once for the source-of-truth banner.
-  useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      const cfg = await getAdminConfig();
-      if (!cancelled && cfg) setIamMode(cfg.iam_mode);
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
+  // IAM mode for the source-of-truth banner (cached react-query read).
+  const { data: cfg } = useAdminConfig();
+  const iamMode = cfg?.iam_mode;
 
   const loadData = useCallback(async () => {
     setLoading(true);

--- a/demo/s3-browser/ui/src/components/InspectorPanel.tsx
+++ b/demo/s3-browser/ui/src/components/InspectorPanel.tsx
@@ -260,9 +260,16 @@ export default function InspectorPanel({
 
   // Fetch bucket policy (compression + public prefixes) once per bucket — skip when the user
   // has not signed in through Settings (would 403).
+  //
+  // `getBucket()` is a non-reactive module getter, so we read it during render
+  // into `currentBucket` and make THAT an explicit effect dependency. Previously
+  // the effect depended only on `[objectKey, hasAdminSession]`, which lied about
+  // its real trigger (the bucket) and only worked because object selection
+  // happens to change with the bucket — a latent stale-policy bug.
+  const currentBucket = getBucket();
   const lastBucketRef = useRef<string>('');
   useEffect(() => {
-    const bucket = getBucket();
+    const bucket = currentBucket;
     if (!bucket) {
       setBucketPolicy(null);
       setBucketPolicyLoading(false);
@@ -300,7 +307,7 @@ export default function InspectorPanel({
     return () => {
       cancelled = true;
     };
-  }, [objectKey, hasAdminSession]);
+  }, [currentBucket, hasAdminSession]);
 
   useEffect(() => {
     if (!objectKey) { setHeadData(null); setHeadReadable(false); return; }

--- a/demo/s3-browser/ui/src/components/LifecyclePanel.tsx
+++ b/demo/s3-browser/ui/src/components/LifecyclePanel.tsx
@@ -368,7 +368,7 @@ export default function LifecyclePanel({ onSessionExpired }: Props) {
           title="Object lifecycle"
           description="Delete-only expiration rules. Preview is read-only; run-now is explicit and guarded."
         />
-        <div style={formRow(16, { flexWrap: 'wrap', marginTop: 14 })}>
+        <div style={formRow(16, { flexWrap: 'wrap' })}>
           <label style={formRow(8)}>
             <Switch checked={lifecycle.enabled} onChange={(enabled) => updateConfig({ enabled })} />
             <Text strong>Automatic scheduler</Text>

--- a/demo/s3-browser/ui/src/components/ReplicationPanel.tsx
+++ b/demo/s3-browser/ui/src/components/ReplicationPanel.tsx
@@ -265,7 +265,7 @@ export default function ReplicationPanel({ onSessionExpired }: Props) {
           title="Object replication"
           description="Copy object data between buckets or prefixes through the DeltaGlider engine, preserving encryption and compression transparency."
         />
-        <div style={{ display: 'flex', gap: 16, flexWrap: 'wrap', marginTop: 14, alignItems: 'center' }}>
+        <div style={{ display: 'flex', gap: 16, flexWrap: 'wrap', alignItems: 'center' }}>
           <label style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
             <Switch checked={replication.enabled} onChange={(v) => updateConfig({ enabled: v })} />
             <Text strong>Automatic scheduler</Text>

--- a/demo/s3-browser/ui/src/components/RuleListEditor.tsx
+++ b/demo/s3-browser/ui/src/components/RuleListEditor.tsx
@@ -67,7 +67,7 @@ export default function RuleListEditor<TRule>({
           title="Rules"
           description={loading ? 'Loading...' : `${rules.length} configured rule${rules.length === 1 ? '' : 's'}.`}
         />
-        <div style={{ marginTop: 12, display: 'flex', flexDirection: 'column', gap: 8 }}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
           {rules.map((rule) => {
             const name = getName(rule);
             const active = selectedKey === name;

--- a/demo/s3-browser/ui/src/components/SectionHeader.tsx
+++ b/demo/s3-browser/ui/src/components/SectionHeader.tsx
@@ -1,33 +1,73 @@
-import { Typography } from 'antd';
 import { useColors } from '../ThemeContext';
 
-const { Text } = Typography;
-
-export default function SectionHeader({ icon, title, description }: { icon: React.ReactNode; title: React.ReactNode; description?: string }) {
+/**
+ * Card header: icon in its own column, title + description STACKED in a second
+ * column so they share one left edge (the "invisible box") with no magic margin.
+ * The icon is vertically centered against the title line. Title is the largest,
+ * boldest thing in the card; description is clearly subordinate.
+ *
+ * Owns its own `marginBottom: 20` so the header→body gap is consistent across
+ * every panel — call sites should NOT add their own `marginTop` to the wrapper
+ * that immediately follows a SectionHeader.
+ */
+export default function SectionHeader({
+  icon,
+  title,
+  description,
+}: {
+  icon: React.ReactNode;
+  title: React.ReactNode;
+  description?: string;
+}) {
   const { ACCENT_BLUE, TEXT_PRIMARY, TEXT_MUTED } = useColors();
   return (
-    <div style={{ marginBottom: 2 }}>
-      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-        <div style={{
-          width: 24,
-          height: 24,
-          borderRadius: 6,
+    <div style={{ display: 'flex', gap: 12, alignItems: 'flex-start', marginBottom: 20 }}>
+      <div
+        style={{
+          width: 32,
+          height: 32,
+          borderRadius: 8,
           background: `linear-gradient(135deg, ${ACCENT_BLUE}18, ${ACCENT_BLUE}08)`,
           border: `1px solid ${ACCENT_BLUE}22`,
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
           flexShrink: 0,
-          fontSize: 12,
+          fontSize: 16,
           color: ACCENT_BLUE,
-        }}>
-          {icon}
-        </div>
-        <Text strong style={{ fontFamily: "var(--font-ui)", fontSize: 14, color: TEXT_PRIMARY, lineHeight: 1.2 }}>{title}</Text>
+          // Nudge so the icon optically centers on the title's cap-height.
+          marginTop: 1,
+        }}
+      >
+        {icon}
       </div>
-      {description && (
-        <Text style={{ fontFamily: "var(--font-ui)", fontSize: 12, color: TEXT_MUTED, display: 'block', marginTop: 2, marginLeft: 32, lineHeight: 1.35 }}>{description}</Text>
-      )}
+      <div style={{ minWidth: 0, flex: 1 }}>
+        <div
+          style={{
+            fontFamily: 'var(--font-ui)',
+            fontSize: 17,
+            fontWeight: 700,
+            color: TEXT_PRIMARY,
+            lineHeight: 1.25,
+            letterSpacing: '-0.01em',
+          }}
+        >
+          {title}
+        </div>
+        {description && (
+          <div
+            style={{
+              fontFamily: 'var(--font-ui)',
+              fontSize: 13,
+              color: TEXT_MUTED,
+              marginTop: 3,
+              lineHeight: 1.45,
+            }}
+          >
+            {description}
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/demo/s3-browser/ui/src/components/SlackConnectorCard.tsx
+++ b/demo/s3-browser/ui/src/components/SlackConnectorCard.tsx
@@ -22,7 +22,7 @@
  * No tooltips/popovers (globally disabled in this layout) — native `title=`. No
  * AntD Select popups (broken here) — checkboxes / Radio.Button only.
  */
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { Button, Checkbox, Input, Radio, Space, Typography } from 'antd';
 import {
   CloseCircleFilled,
@@ -37,9 +37,11 @@ import FormField from './FormField';
 import { AdvancedDisclosure } from './ruleEditorFields';
 import {
   SLACK_NOTIFY_KINDS,
+  resolveSlackChannelsPreview,
   type WebhookFormState,
   type WebhookUrlRow,
   type SlackGlobRow,
+  type SlackRouteRow,
 } from './webhookDeliveryPayload';
 
 const { Text } = Typography;
@@ -74,6 +76,11 @@ export default function SlackConnectorCard({
 }: Props) {
   const colors = useColors();
 
+  // Sample event for the routing preview. UI-only ephemeral state (not config):
+  // lets the operator see which channel(s) a given bucket/key would resolve to.
+  const [sampleBucket, setSampleBucket] = useState('releases');
+  const [sampleKey, setSampleKey] = useState('builds/app.zip');
+
   // Display mode = the operator's UI choice (sticky even with an empty token
   // field). The BACKEND mode is derived from token presence at payload-build
   // time — leaving webhook mode clears the token so the two stay consistent.
@@ -107,6 +114,47 @@ export default function SlackConnectorCard({
     setField({
       [key]: form[key].filter((r) => r.id !== id),
     } as Partial<WebhookFormState>);
+
+  // ── Channel-routing row mutators (stable-id keyed, never array index) ──
+  const updateRoute = (id: string, patch: Partial<SlackRouteRow>) =>
+    setField({
+      slackRoutes: form.slackRoutes.map((r) => (r.id === id ? { ...r, ...patch } : r)),
+    });
+  const addRoute = () =>
+    setField({
+      slackRoutes: [
+        ...form.slackRoutes,
+        { id: nextId(), name: '', bucket: '', prefixGlobs: [], channel: '' } as SlackRouteRow,
+      ],
+    });
+  const removeRoute = (id: string) =>
+    setField({ slackRoutes: form.slackRoutes.filter((r) => r.id !== id) });
+
+  // Nested glob-row mutators scoped to ONE route (stable-id keyed throughout).
+  const updateRouteGlob = (routeId: string, globId: string, glob: string) =>
+    setField({
+      slackRoutes: form.slackRoutes.map((r) =>
+        r.id === routeId
+          ? { ...r, prefixGlobs: r.prefixGlobs.map((g) => (g.id === globId ? { ...g, glob } : g)) }
+          : r,
+      ),
+    });
+  const addRouteGlob = (routeId: string) =>
+    setField({
+      slackRoutes: form.slackRoutes.map((r) =>
+        r.id === routeId
+          ? { ...r, prefixGlobs: [...r.prefixGlobs, { id: nextId(), glob: '' } as SlackGlobRow] }
+          : r,
+      ),
+    });
+  const removeRouteGlob = (routeId: string, globId: string) =>
+    setField({
+      slackRoutes: form.slackRoutes.map((r) =>
+        r.id === routeId
+          ? { ...r, prefixGlobs: r.prefixGlobs.filter((g) => g.id !== globId) }
+          : r,
+      ),
+    });
 
   const toggleKind = (kind: string, on: boolean) => {
     const set = new Set(form.slackNotifyKinds);
@@ -194,6 +242,25 @@ export default function SlackConnectorCard({
         <BotModeFields form={form} setField={setField} inputRadius={inputRadius} colors={colors} />
       )}
 
+      {/* Channel routing — bot-token mode only (Incoming Webhook URLs are each
+          bound to one channel by Slack, so per-bucket/prefix routing needs the
+          Web API). Collapsed by default; the channel above is the fallback. */}
+      {mode === 'bot' && (
+        <AdvancedDisclosure title="Channel routing (per bucket / prefix)">
+          <ChannelRoutingEditor
+            form={form}
+            inputRadius={inputRadius}
+            colors={colors}
+            updateRoute={updateRoute}
+            addRoute={addRoute}
+            removeRoute={removeRoute}
+            updateRouteGlob={updateRouteGlob}
+            addRouteGlob={addRouteGlob}
+            removeRouteGlob={removeRouteGlob}
+          />
+        </AdvancedDisclosure>
+      )}
+
       {/* What gets posted */}
       <AdvancedDisclosure title="What gets posted (event kinds + prefix filters)">
         <FormField
@@ -253,6 +320,17 @@ export default function SlackConnectorCard({
         >
           Live preview — what lands in the channel
         </Text>
+        {mode === 'bot' && form.slackRoutes.length > 0 && (
+          <RoutingPreview
+            form={form}
+            colors={colors}
+            inputRadius={inputRadius}
+            sampleBucket={sampleBucket}
+            sampleKey={sampleKey}
+            onBucket={setSampleBucket}
+            onKey={setSampleKey}
+          />
+        )}
         <SlackPreview form={form} mode={mode} colors={colors} />
       </div>
 
@@ -470,7 +548,7 @@ function GlobRowsField({
   placeholder,
 }: {
   label: string;
-  yamlPath: string;
+  yamlPath?: string;
   helpText: string;
   rows: SlackGlobRow[];
   onUpdate: (id: string, glob: string) => void;
@@ -504,6 +582,231 @@ function GlobRowsField({
       </Space>
     </FormField>
   );
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Channel routing editor (bot-token mode only) — per bucket / prefix → channel.
+// Stable-id row keys throughout (routes AND their nested glob rows), edited
+// directly through the shared useSectionEditor value (no parallel state).
+// ─────────────────────────────────────────────────────────────────────────
+
+function ChannelRoutingEditor({
+  form,
+  inputRadius,
+  colors,
+  updateRoute,
+  addRoute,
+  removeRoute,
+  updateRouteGlob,
+  addRouteGlob,
+  removeRouteGlob,
+}: {
+  form: WebhookFormState;
+  inputRadius: React.CSSProperties;
+  colors: ReturnType<typeof useColors>;
+  updateRoute: (id: string, patch: Partial<SlackRouteRow>) => void;
+  addRoute: () => void;
+  removeRoute: (id: string) => void;
+  updateRouteGlob: (routeId: string, globId: string, glob: string) => void;
+  addRouteGlob: (routeId: string) => void;
+  removeRouteGlob: (routeId: string, globId: string) => void;
+}) {
+  return (
+    <div>
+      <Text type="secondary" style={{ fontSize: 12, display: 'block', marginBottom: 12, lineHeight: 1.5 }}>
+        Send different buckets or prefixes to different channels. An event posts
+        to every route it matches; the channel above is the fallback for
+        unmatched events.
+      </Text>
+
+      <Space direction="vertical" size={12} style={{ width: '100%' }}>
+        {form.slackRoutes.length === 0 && (
+          <Text type="secondary" style={{ fontSize: 12 }}>
+            No routes — every event posts to the single channel above.
+          </Text>
+        )}
+        {form.slackRoutes.map((route, i) => (
+          <div
+            key={route.id}
+            style={{
+              border: `1px solid ${colors.BORDER}`,
+              borderRadius: 8,
+              padding: 12,
+              background: colors.BG_CARD,
+            }}
+          >
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                marginBottom: 10,
+              }}
+            >
+              <Text style={{ fontSize: 11, fontWeight: 700, letterSpacing: 0.5, textTransform: 'uppercase', color: colors.TEXT_MUTED }}>
+                Route {i + 1}
+              </Text>
+              <Button
+                icon={<DeleteOutlined />}
+                size="small"
+                onClick={() => removeRoute(route.id)}
+                title="Remove route"
+              />
+            </div>
+
+            <FormField label="Name (optional)">
+              <Input
+                value={route.name}
+                onChange={(e) => updateRoute(route.id, { name: e.target.value })}
+                placeholder="e.g. Releases → #ci"
+                style={{ ...inputRadius, fontSize: 13, maxWidth: 320 }}
+              />
+            </FormField>
+
+            <FormField label="Bucket">
+              <Input
+                value={route.bucket}
+                onChange={(e) => updateRoute(route.id, { bucket: e.target.value })}
+                placeholder="any bucket"
+                style={{ ...inputRadius, fontFamily: 'var(--font-mono)', fontSize: 13, maxWidth: 280 }}
+              />
+            </FormField>
+
+            <FormField
+              label={
+                <span>
+                  Channel{' '}
+                  <span style={{ color: colors.ACCENT_RED, fontWeight: 700 }} title="Required">
+                    *
+                  </span>
+                </span>
+              }
+              helpText="Required. Channel id (C0123…) or #name."
+            >
+              <Input
+                value={route.channel}
+                onChange={(e) => updateRoute(route.id, { channel: e.target.value })}
+                placeholder="C0123 or #name"
+                status={route.channel.trim().length === 0 ? 'error' : undefined}
+                style={{ ...inputRadius, fontFamily: 'var(--font-mono)', fontSize: 13, maxWidth: 280 }}
+              />
+            </FormField>
+
+            <GlobRowsField
+              label="Prefix globs"
+              helpText="Keys matching at least one glob route here. Empty = any key."
+              rows={route.prefixGlobs}
+              onUpdate={(globId, g) => updateRouteGlob(route.id, globId, g)}
+              onAdd={() => addRouteGlob(route.id)}
+              onRemove={(globId) => removeRouteGlob(route.id, globId)}
+              inputRadius={inputRadius}
+              placeholder="builds/** (empty = any key)"
+            />
+          </div>
+        ))}
+        <Button icon={<PlusOutlined />} onClick={addRoute} size="small">
+          Add route
+        </Button>
+      </Space>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Routing preview — resolve a SAMPLE bucket/key against the routes, mirroring
+// the Rust resolve_channels (fan-out to all matches; fallback to the single
+// channel; or nowhere). Best-effort client-side glob match.
+// ─────────────────────────────────────────────────────────────────────────
+
+function RoutingPreview({
+  form,
+  colors,
+  inputRadius,
+  sampleBucket,
+  sampleKey,
+  onBucket,
+  onKey,
+}: {
+  form: WebhookFormState;
+  colors: ReturnType<typeof useColors>;
+  inputRadius: React.CSSProperties;
+  sampleBucket: string;
+  sampleKey: string;
+  onBucket: (v: string) => void;
+  onKey: (v: string) => void;
+}) {
+  const resolved = useMemo(
+    () => resolveSlackChannelsPreview(form.slackRoutes, form.slackChannel, sampleBucket, sampleKey),
+    [form.slackRoutes, form.slackChannel, sampleBucket, sampleKey],
+  );
+
+  const chipBase: React.CSSProperties = {
+    fontFamily: 'var(--font-mono)',
+    fontSize: 12,
+    borderRadius: 4,
+    padding: '1px 7px',
+    border: `1px solid ${colors.BORDER}`,
+  };
+
+  return (
+    <div
+      style={{
+        marginBottom: 12,
+        padding: 12,
+        border: `1px dashed ${colors.BORDER}`,
+        borderRadius: 8,
+      }}
+    >
+      <Text style={{ fontSize: 12, color: colors.TEXT_MUTED, display: 'block', marginBottom: 8 }}>
+        Resolve a sample event:
+      </Text>
+      <Space.Compact style={{ width: '100%', maxWidth: 420, marginBottom: 10 }}>
+        <Input
+          value={sampleBucket}
+          onChange={(e) => onBucket(e.target.value)}
+          placeholder="bucket"
+          style={{ ...inputRadius, fontFamily: 'var(--font-mono)', fontSize: 13, maxWidth: 150 }}
+          title="Sample bucket"
+        />
+        <Input
+          value={sampleKey}
+          onChange={(e) => onKey(e.target.value)}
+          placeholder="path/to/key.zip"
+          style={{ ...inputRadius, fontFamily: 'var(--font-mono)', fontSize: 13 }}
+          title="Sample object key"
+        />
+      </Space.Compact>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap', fontSize: 13 }}>
+        <span style={{ color: colors.TEXT_MUTED }}>→</span>
+        {resolved.matches.length > 0 ? (
+          resolved.matches.map((m) => (
+            <span
+              key={m.channel}
+              style={{ ...chipBase, color: colors.ACCENT_BLUE }}
+              title={`Matched route: ${m.label}`}
+            >
+              {fmtChannel(m.channel)}
+            </span>
+          ))
+        ) : resolved.fellBackToChannel ? (
+          <span style={{ ...chipBase, color: colors.TEXT_SECONDARY }} title="No route matched — fallback channel">
+            (fallback) {fmtChannel(resolved.fallbackChannel)}
+          </span>
+        ) : (
+          <span style={{ ...chipBase, color: colors.TEXT_MUTED }} title="No route matched and no fallback channel set">
+            (no channel)
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** Display a channel as `#name` / `C0123…` (prefix-aware), like Slack shows it. */
+function fmtChannel(c: string): string {
+  const t = c.trim();
+  if (!t) return '';
+  return t.startsWith('#') || t.startsWith('C') ? t : `#${t}`;
 }
 
 // ─────────────────────────────────────────────────────────────────────────

--- a/demo/s3-browser/ui/src/components/SlackConnectorCard.tsx
+++ b/demo/s3-browser/ui/src/components/SlackConnectorCard.tsx
@@ -29,12 +29,13 @@ import {
   DeleteOutlined,
   InfoCircleOutlined,
   PlusOutlined,
+  QuestionCircleOutlined,
   SlackOutlined,
 } from '@ant-design/icons';
 import { useColors } from '../ThemeContext';
 import SectionHeader from './SectionHeader';
 import FormField from './FormField';
-import SlackSetupGuide from './SlackSetupGuide';
+import { SlackSetupGuideDrawer } from './SlackSetupGuide';
 import { AdvancedDisclosure } from './ruleEditorFields';
 import {
   SLACK_NOTIFY_KINDS,
@@ -61,6 +62,8 @@ interface Props {
   updateUrl: (id: string, url: string) => void;
   addUrl: () => void;
   removeUrl: (id: string) => void;
+  /** Below ~900px the two-column form/preview split collapses to one column. */
+  isNarrow: boolean;
 }
 
 
@@ -73,6 +76,7 @@ export default function SlackConnectorCard({
   updateUrl,
   addUrl,
   removeUrl,
+  isNarrow,
 }: Props) {
   const colors = useColors();
 
@@ -80,6 +84,10 @@ export default function SlackConnectorCard({
   // lets the operator see which channel(s) a given bucket/key would resolve to.
   const [sampleBucket, setSampleBucket] = useState('releases');
   const [sampleKey, setSampleKey] = useState('builds/app.zip');
+
+  // Setup-guide drawer (UI-only local state — never touches config). Opens the
+  // roomy step-by-step guide for the mode currently being edited.
+  const [guideOpen, setGuideOpen] = useState(false);
 
   // Display mode = the operator's UI choice (sticky even with an empty token
   // field). The BACKEND mode is derived from token presence at payload-build
@@ -164,10 +172,9 @@ export default function SlackConnectorCard({
     setField({ slackNotifyKinds: SLACK_NOTIFY_KINDS.filter((k) => set.has(k)) });
   };
 
-  return (
-    // No outer card here — the parent panel wraps this in the accent-bordered
-    // "destination" card so the raw and Slack connectors share one frame.
-    <>
+  // ── LEFT column: header + the whole config form ──
+  const formColumn = (
+    <div style={{ minWidth: 0 }}>
       <SectionHeader
         icon={<SlackOutlined />}
         title="Slack connector"
@@ -177,15 +184,15 @@ export default function SlackConnectorCard({
       {/* No-OAuth note — discreet one-liner, not a banner. */}
       <div
         style={{
-          marginTop: 12,
+          marginTop: 14,
           display: 'flex',
           alignItems: 'center',
-          gap: 7,
-          fontSize: 12,
+          gap: 8,
+          fontSize: 13,
           color: colors.TEXT_MUTED,
         }}
       >
-        <InfoCircleOutlined style={{ color: colors.ACCENT_BLUE, fontSize: 13 }} />
+        <InfoCircleOutlined style={{ color: colors.ACCENT_BLUE, fontSize: 14 }} />
         <span title="Delivery is outbound HTTPS only — Slack never needs to reach back to this proxy, so it works on private/internal instances.">
           No OAuth — just paste a credential. Works on private / internal instances.
         </span>
@@ -194,21 +201,21 @@ export default function SlackConnectorCard({
       {errors.length > 0 && (
         <div
           style={{
-            marginTop: 10,
-            fontSize: 12,
+            marginTop: 12,
+            fontSize: 13,
             color: colors.ACCENT_RED,
             display: 'flex',
             alignItems: 'flex-start',
-            gap: 7,
+            gap: 8,
           }}
         >
-          <CloseCircleFilled style={{ marginTop: 2, fontSize: 13 }} />
+          <CloseCircleFilled style={{ marginTop: 2, fontSize: 14 }} />
           <span>{errors.join(' · ')}</span>
         </div>
       )}
 
       {/* Mode sub-toggle */}
-      <div style={{ marginTop: 16 }}>
+      <div style={{ marginTop: 20 }}>
         <FormField
           label="How to connect"
           helpText="Incoming Webhook is the quickest. Use a bot token when you need multiple channels or @mentions."
@@ -218,10 +225,10 @@ export default function SlackConnectorCard({
             onChange={(e) => setMode(e.target.value as SlackMode)}
             style={{ display: 'flex', gap: 0 }}
           >
-            <Radio.Button value="webhook" style={{ fontSize: 13 }} title="Post via a hooks.slack.com Incoming Webhook URL">
+            <Radio.Button value="webhook" style={{ fontSize: 14 }} title="Post via a hooks.slack.com Incoming Webhook URL">
               Incoming Webhook (simplest)
             </Radio.Button>
-            <Radio.Button value="bot" style={{ fontSize: 13 }} title="Post via the Slack Web API with a bot token">
+            <Radio.Button value="bot" style={{ fontSize: 14 }} title="Post via the Slack Web API with a bot token">
               Bot token (multi-channel + @mentions)
             </Radio.Button>
           </Radio.Group>
@@ -268,14 +275,14 @@ export default function SlackConnectorCard({
           yamlPath="advanced.event_delivery.slack_notify_kinds"
           helpText="Only these event kinds are posted to Slack. ObjectCreated is the default."
         >
-          <Space direction="vertical" size={4} style={{ width: '100%' }}>
+          <Space direction="vertical" size={6} style={{ width: '100%' }}>
             {SLACK_NOTIFY_KINDS.map((kind) => (
               <Checkbox
                 key={kind}
                 checked={form.slackNotifyKinds.includes(kind)}
                 onChange={(e) => toggleKind(kind, e.target.checked)}
               >
-                <span style={{ fontFamily: 'var(--font-mono)', fontSize: 13 }}>{kind}</span>
+                <span style={{ fontFamily: 'var(--font-mono)', fontSize: 14 }}>{kind}</span>
               </Checkbox>
             ))}
           </Space>
@@ -304,6 +311,24 @@ export default function SlackConnectorCard({
           placeholder="tmp/**"
         />
       </AdvancedDisclosure>
+    </div>
+  );
+
+  // ── RIGHT column: setup-help entry + the live preview, pinned ──
+  const sideColumn = (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 20,
+        // On wide viewports the preview tracks the operator as they scroll the
+        // (taller) form column; on narrow it just flows after the form.
+        position: isNarrow ? 'static' : 'sticky',
+        top: 16,
+        alignSelf: 'flex-start',
+      }}
+    >
+      <SetupHelpCard mode={mode} colors={colors} onOpen={() => setGuideOpen(true)} />
 
       {/* Live preview — ONE sample event drives both the resolved-channel chips
           AND the faux Slack message, so they never tell contradictory stories. */}
@@ -317,7 +342,69 @@ export default function SlackConnectorCard({
         onBucket={setSampleBucket}
         onKey={setSampleKey}
       />
+    </div>
+  );
+
+  return (
+    // No outer card here — the parent panel wraps this in the accent-bordered
+    // "destination" card so the raw and Slack connectors share one frame.
+    <>
+      <div
+        style={{
+          display: 'grid',
+          // Form takes the flexible left; the preview/help sits in a fixed-ish
+          // right rail. Collapses to a single stacked column under ~900px.
+          gridTemplateColumns: isNarrow ? '1fr' : 'minmax(0, 1fr) minmax(340px, 400px)',
+          gap: isNarrow ? 28 : 40,
+          alignItems: 'start',
+        }}
+      >
+        {formColumn}
+        {sideColumn}
+      </div>
+
+      <SlackSetupGuideDrawer open={guideOpen} mode={mode} onClose={() => setGuideOpen(false)} />
     </>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Setup-help entry — replaces the inline guide. A calm card with a one-liner
+// and a button that opens the roomy step-by-step guide in a drawer.
+// ─────────────────────────────────────────────────────────────────────────
+
+function SetupHelpCard({
+  mode,
+  colors,
+  onOpen,
+}: {
+  mode: SlackMode;
+  colors: ReturnType<typeof useColors>;
+  onOpen: () => void;
+}) {
+  return (
+    <div
+      style={{
+        border: `1px solid ${colors.BORDER}`,
+        borderRadius: 12,
+        background: colors.BG_ELEVATED,
+        padding: 18,
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 9, marginBottom: 8 }}>
+        <SlackOutlined style={{ color: '#611f69', fontSize: 18 }} />
+        <span style={{ fontSize: 14, fontWeight: 600, color: colors.TEXT_PRIMARY }}>
+          Need a Slack app?
+        </span>
+      </div>
+      <div style={{ fontSize: 13, color: colors.TEXT_MUTED, lineHeight: 1.6, marginBottom: 14 }}>
+        One-time setup, ~2 minutes. We&apos;ll walk you through creating the app and grabbing the{' '}
+        {mode === 'webhook' ? 'webhook URL' : 'bot token'} — with screenshots.
+      </div>
+      <Button icon={<QuestionCircleOutlined />} onClick={onOpen} block>
+        Set up a Slack app
+      </Button>
+    </div>
   );
 }
 
@@ -342,10 +429,8 @@ function WebhookModeFields({
   setField: (patch: Partial<WebhookFormState>) => void;
   colors: ReturnType<typeof useColors>;
 }) {
-  const noEndpoints = form.urlRows.every((r) => !r.url.trim());
   return (
     <div style={{ marginTop: 8 }}>
-      <SlackSetupGuide mode="webhook" defaultOpen={noEndpoints} />
       <FormField
         label="Incoming Webhook URL"
         yamlPath="advanced.event_delivery.webhook_urls"
@@ -353,7 +438,7 @@ function WebhookModeFields({
       >
         <Space direction="vertical" style={{ width: '100%' }}>
           {form.urlRows.length === 0 && (
-            <Text type="secondary" style={{ fontSize: 12 }}>
+            <Text type="secondary" style={{ fontSize: 13 }}>
               No webhook URL yet. Add the one Slack gave you.
             </Text>
           )}
@@ -363,7 +448,7 @@ function WebhookModeFields({
                 value={row.url}
                 onChange={(e) => updateUrl(row.id, e.target.value)}
                 placeholder="https://hooks.slack.com/services/T000/B000/xxxx"
-                style={{ ...inputRadius, fontFamily: 'var(--font-mono)', fontSize: 13 }}
+                style={{ ...inputRadius, fontFamily: 'var(--font-mono)', fontSize: 14 }}
               />
               <Button
                 icon={<DeleteOutlined />}
@@ -387,7 +472,7 @@ function WebhookModeFields({
           value={form.slackUsername}
           onChange={(e) => setField({ slackUsername: e.target.value })}
           placeholder="DeltaGlider"
-          style={{ ...inputRadius, fontSize: 13, maxWidth: 280 }}
+          style={{ ...inputRadius, fontSize: 14, maxWidth: 360 }}
         />
       </FormField>
 
@@ -400,7 +485,7 @@ function WebhookModeFields({
           value={form.slackIconEmoji}
           onChange={(e) => setField({ slackIconEmoji: e.target.value })}
           placeholder=":package:"
-          style={{ ...inputRadius, fontFamily: 'var(--font-mono)', fontSize: 13, maxWidth: 200, color: colors.TEXT_PRIMARY }}
+          style={{ ...inputRadius, fontFamily: 'var(--font-mono)', fontSize: 14, maxWidth: 280, color: colors.TEXT_PRIMARY }}
         />
       </FormField>
     </div>
@@ -418,12 +503,8 @@ function BotModeFields({
   inputRadius: React.CSSProperties;
   colors: ReturnType<typeof useColors>;
 }) {
-  // Open the guide by default when no token is configured yet (neither a
-  // server-masked one nor a freshly-typed value).
-  const noToken = !form.slackBotTokenMasked && !form.slackBotToken.trim();
   return (
     <div style={{ marginTop: 8 }}>
-      <SlackSetupGuide mode="bot" defaultOpen={noToken} />
       <FormField
         label="Bot token"
         yamlPath="advanced.event_delivery.slack_bot_token"
@@ -440,7 +521,7 @@ function BotModeFields({
               ? '•••••••• (unchanged — type to replace)'
               : 'xoxb-…'
           }
-          style={{ ...inputRadius, fontFamily: 'var(--font-mono)', fontSize: 13, maxWidth: 420, color: colors.TEXT_PRIMARY }}
+          style={{ ...inputRadius, fontFamily: 'var(--font-mono)', fontSize: 14, maxWidth: 480, color: colors.TEXT_PRIMARY }}
         />
       </FormField>
 
@@ -453,7 +534,7 @@ function BotModeFields({
           value={form.slackChannel}
           onChange={(e) => setField({ slackChannel: e.target.value })}
           placeholder="#deploys or C0123ABC"
-          style={{ ...inputRadius, fontFamily: 'var(--font-mono)', fontSize: 13, maxWidth: 280 }}
+          style={{ ...inputRadius, fontFamily: 'var(--font-mono)', fontSize: 14, maxWidth: 360 }}
         />
       </FormField>
     </div>
@@ -485,17 +566,17 @@ function GlobRowsField({
     <FormField label={label} yamlPath={yamlPath} helpText={helpText}>
       <Space direction="vertical" style={{ width: '100%' }}>
         {rows.length === 0 && (
-          <Text type="secondary" style={{ fontSize: 12 }}>
+          <Text type="secondary" style={{ fontSize: 13 }}>
             None.
           </Text>
         )}
         {rows.map((row) => (
-          <Space.Compact key={row.id} style={{ width: '100%', maxWidth: 420 }}>
+          <Space.Compact key={row.id} style={{ width: '100%', maxWidth: 480 }}>
             <Input
               value={row.glob}
               onChange={(e) => onUpdate(row.id, e.target.value)}
               placeholder={placeholder}
-              style={{ ...inputRadius, fontFamily: 'var(--font-mono)', fontSize: 13 }}
+              style={{ ...inputRadius, fontFamily: 'var(--font-mono)', fontSize: 14 }}
             />
             <Button icon={<DeleteOutlined />} onClick={() => onRemove(row.id)} title="Remove glob" />
           </Space.Compact>
@@ -537,15 +618,15 @@ function ChannelRoutingEditor({
 }) {
   return (
     <div>
-      <Text type="secondary" style={{ fontSize: 12, display: 'block', marginBottom: 12, lineHeight: 1.5 }}>
+      <Text type="secondary" style={{ fontSize: 13, display: 'block', marginBottom: 14, lineHeight: 1.6 }}>
         Send different buckets or prefixes to different channels. An event posts
         to every route it matches; the channel above is the fallback for
         unmatched events.
       </Text>
 
-      <Space direction="vertical" size={12} style={{ width: '100%' }}>
+      <Space direction="vertical" size={14} style={{ width: '100%' }}>
         {form.slackRoutes.length === 0 && (
-          <Text type="secondary" style={{ fontSize: 12 }}>
+          <Text type="secondary" style={{ fontSize: 13 }}>
             No routes — every event posts to the single channel above.
           </Text>
         )}
@@ -554,8 +635,8 @@ function ChannelRoutingEditor({
             key={route.id}
             style={{
               border: `1px solid ${colors.BORDER}`,
-              borderRadius: 8,
-              padding: 12,
+              borderRadius: 10,
+              padding: 16,
               background: colors.BG_CARD,
             }}
           >
@@ -583,7 +664,7 @@ function ChannelRoutingEditor({
                 value={route.name}
                 onChange={(e) => updateRoute(route.id, { name: e.target.value })}
                 placeholder="e.g. Releases → #ci"
-                style={{ ...inputRadius, fontSize: 13, maxWidth: 320 }}
+                style={{ ...inputRadius, fontSize: 14, maxWidth: 380 }}
               />
             </FormField>
 
@@ -592,7 +673,7 @@ function ChannelRoutingEditor({
                 value={route.bucket}
                 onChange={(e) => updateRoute(route.id, { bucket: e.target.value })}
                 placeholder="any bucket"
-                style={{ ...inputRadius, fontFamily: 'var(--font-mono)', fontSize: 13, maxWidth: 280 }}
+                style={{ ...inputRadius, fontFamily: 'var(--font-mono)', fontSize: 14, maxWidth: 360 }}
               />
             </FormField>
 
@@ -612,7 +693,7 @@ function ChannelRoutingEditor({
                 onChange={(e) => updateRoute(route.id, { channel: e.target.value })}
                 placeholder="C0123 or #name"
                 status={route.channel.trim().length === 0 ? 'error' : undefined}
-                style={{ ...inputRadius, fontFamily: 'var(--font-mono)', fontSize: 13, maxWidth: 280 }}
+                style={{ ...inputRadius, fontFamily: 'var(--font-mono)', fontSize: 14, maxWidth: 360 }}
               />
             </FormField>
 
@@ -688,14 +769,21 @@ function LivePreview({
 
   const chipBase: React.CSSProperties = {
     fontFamily: 'var(--font-mono)',
-    fontSize: 12,
+    fontSize: 13,
     borderRadius: 4,
-    padding: '1px 7px',
+    padding: '2px 8px',
     border: `1px solid ${colors.BORDER}`,
   };
 
   return (
-    <div style={{ marginTop: 20 }}>
+    <div
+      style={{
+        border: `1px solid ${colors.BORDER}`,
+        borderRadius: 12,
+        background: colors.BG_ELEVATED,
+        padding: 18,
+      }}
+    >
       <Text
         type="secondary"
         style={{
@@ -704,7 +792,7 @@ function LivePreview({
           letterSpacing: 0.5,
           textTransform: 'uppercase',
           display: 'block',
-          marginBottom: 8,
+          marginBottom: 12,
         }}
       >
         Live preview — what lands in the channel
@@ -714,32 +802,32 @@ function LivePreview({
       {mode === 'bot' && (
         <div
           style={{
-            marginBottom: 12,
-            padding: 12,
+            marginBottom: 16,
+            padding: 14,
             border: `1px dashed ${colors.BORDER}`,
             borderRadius: 8,
           }}
         >
-          <Text style={{ fontSize: 12, color: colors.TEXT_MUTED, display: 'block', marginBottom: 8 }}>
+          <Text style={{ fontSize: 13, color: colors.TEXT_MUTED, display: 'block', marginBottom: 10 }}>
             Try a sample event{routed ? '' : ' (add routes to send buckets to different channels)'}:
           </Text>
-          <Space.Compact style={{ width: '100%', maxWidth: 420, marginBottom: 10 }}>
+          <Space.Compact style={{ width: '100%', marginBottom: 12 }}>
             <Input
               value={sampleBucket}
               onChange={(e) => onBucket(e.target.value)}
               placeholder="bucket"
-              style={{ ...inputRadius, fontFamily: 'var(--font-mono)', fontSize: 13, maxWidth: 150 }}
+              style={{ ...inputRadius, fontFamily: 'var(--font-mono)', fontSize: 14, maxWidth: 150 }}
               title="Sample bucket"
             />
             <Input
               value={sampleKey}
               onChange={(e) => onKey(e.target.value)}
               placeholder="path/to/key.zip"
-              style={{ ...inputRadius, fontFamily: 'var(--font-mono)', fontSize: 13 }}
+              style={{ ...inputRadius, fontFamily: 'var(--font-mono)', fontSize: 14 }}
               title="Sample object key"
             />
           </Space.Compact>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap', fontSize: 13 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap', fontSize: 14 }}>
             <span style={{ color: colors.TEXT_MUTED }}>→</span>
             {resolved.matches.length > 0 ? (
               resolved.matches.map((m) => (

--- a/demo/s3-browser/ui/src/components/SlackConnectorCard.tsx
+++ b/demo/s3-browser/ui/src/components/SlackConnectorCard.tsx
@@ -34,6 +34,7 @@ import {
 import { useColors } from '../ThemeContext';
 import SectionHeader from './SectionHeader';
 import FormField from './FormField';
+import SlackSetupGuide from './SlackSetupGuide';
 import { AdvancedDisclosure } from './ruleEditorFields';
 import {
   SLACK_NOTIFY_KINDS,
@@ -62,7 +63,6 @@ interface Props {
   removeUrl: (id: string) => void;
 }
 
-const APP_LINK = 'https://api.slack.com/apps?new_app=1';
 
 export default function SlackConnectorCard({
   form,
@@ -317,13 +317,6 @@ export default function SlackConnectorCard({
         onBucket={setSampleBucket}
         onKey={setSampleKey}
       />
-
-      <Text type="secondary" style={{ fontSize: 11, display: 'block', marginTop: 12 }}>
-        Need an app?{' '}
-        <a href={APP_LINK} target="_blank" rel="noreferrer">
-          Create a Slack app →
-        </a>
-      </Text>
     </>
   );
 }
@@ -331,50 +324,6 @@ export default function SlackConnectorCard({
 // ─────────────────────────────────────────────────────────────────────────
 // Mode-specific field groups
 // ─────────────────────────────────────────────────────────────────────────
-
-function MiniGuide({ steps }: { steps: string[] }) {
-  const { TEXT_MUTED, BORDER } = useColors();
-  return (
-    <ol
-      style={{
-        margin: '0 0 12px',
-        paddingLeft: 0,
-        listStyle: 'none',
-        counterReset: 'slk',
-        borderLeft: `2px solid ${BORDER}`,
-      }}
-    >
-      {steps.map((s, i) => (
-        <li
-          key={i}
-          style={{
-            counterIncrement: 'slk',
-            position: 'relative',
-            paddingLeft: 28,
-            marginBottom: 6,
-            fontSize: 12,
-            color: TEXT_MUTED,
-            lineHeight: 1.4,
-          }}
-        >
-          <span
-            aria-hidden="true"
-            style={{
-              position: 'absolute',
-              left: 8,
-              top: 0,
-              fontWeight: 700,
-              fontFamily: 'var(--font-mono)',
-            }}
-          >
-            {i + 1}.
-          </span>
-          {s}
-        </li>
-      ))}
-    </ol>
-  );
-}
 
 function WebhookModeFields({
   form,
@@ -393,15 +342,10 @@ function WebhookModeFields({
   setField: (patch: Partial<WebhookFormState>) => void;
   colors: ReturnType<typeof useColors>;
 }) {
+  const noEndpoints = form.urlRows.every((r) => !r.url.trim());
   return (
     <div style={{ marginTop: 8 }}>
-      <MiniGuide
-        steps={[
-          'Create a Slack app (or open an existing one).',
-          'Enable “Incoming Webhooks” and add one for your channel.',
-          'Paste the hooks.slack.com webhook URL below.',
-        ]}
-      />
+      <SlackSetupGuide mode="webhook" defaultOpen={noEndpoints} />
       <FormField
         label="Incoming Webhook URL"
         yamlPath="advanced.event_delivery.webhook_urls"
@@ -474,16 +418,12 @@ function BotModeFields({
   inputRadius: React.CSSProperties;
   colors: ReturnType<typeof useColors>;
 }) {
+  // Open the guide by default when no token is configured yet (neither a
+  // server-masked one nor a freshly-typed value).
+  const noToken = !form.slackBotTokenMasked && !form.slackBotToken.trim();
   return (
     <div style={{ marginTop: 8 }}>
-      <MiniGuide
-        steps={[
-          'Create a Slack app (or open an existing one).',
-          'Add the chat:write and chat:write.public bot scopes.',
-          'Install the app to your workspace.',
-          'Paste the xoxb- bot token and the target channel below.',
-        ]}
-      />
+      <SlackSetupGuide mode="bot" defaultOpen={noToken} />
       <FormField
         label="Bot token"
         yamlPath="advanced.event_delivery.slack_bot_token"

--- a/demo/s3-browser/ui/src/components/SlackConnectorCard.tsx
+++ b/demo/s3-browser/ui/src/components/SlackConnectorCard.tsx
@@ -184,7 +184,6 @@ export default function SlackConnectorCard({
       {/* No-OAuth note — discreet one-liner, not a banner. */}
       <div
         style={{
-          marginTop: 14,
           display: 'flex',
           alignItems: 'center',
           gap: 8,

--- a/demo/s3-browser/ui/src/components/SlackConnectorCard.tsx
+++ b/demo/s3-browser/ui/src/components/SlackConnectorCard.tsx
@@ -23,10 +23,15 @@
  * AntD Select popups (broken here) — checkboxes / Radio.Button only.
  */
 import { useMemo } from 'react';
-import { Alert, Button, Checkbox, Input, Radio, Space, Typography } from 'antd';
-import { DeleteOutlined, PlusOutlined, SlackOutlined } from '@ant-design/icons';
+import { Button, Checkbox, Input, Radio, Space, Typography } from 'antd';
+import {
+  CloseCircleFilled,
+  DeleteOutlined,
+  InfoCircleOutlined,
+  PlusOutlined,
+  SlackOutlined,
+} from '@ant-design/icons';
 import { useColors } from '../ThemeContext';
-import { useCardStyles } from './shared-styles';
 import SectionHeader from './SectionHeader';
 import FormField from './FormField';
 import { AdvancedDisclosure } from './ruleEditorFields';
@@ -67,7 +72,6 @@ export default function SlackConnectorCard({
   addUrl,
   removeUrl,
 }: Props) {
-  const { cardStyle } = useCardStyles();
   const colors = useColors();
 
   // Display mode = the operator's UI choice (sticky even with an empty token
@@ -113,36 +117,46 @@ export default function SlackConnectorCard({
   };
 
   return (
-    <div style={cardStyle}>
+    // No outer card here — the parent panel wraps this in the accent-bordered
+    // "destination" card so the raw and Slack connectors share one frame.
+    <>
       <SectionHeader
         icon={<SlackOutlined />}
         title="Slack connector"
         description="Post object events to a Slack channel as a formatted message. No restart — applies live."
       />
 
-      {/* No-OAuth callout */}
-      <Alert
-        type="info"
-        showIcon
-        style={{ marginTop: 16 }}
-        message="No OAuth needed — paste a credential."
-        description="Works on private / internal instances (outbound HTTPS only). Slack never needs to reach back to this proxy."
-      />
+      {/* No-OAuth note — discreet one-liner, not a banner. */}
+      <div
+        style={{
+          marginTop: 12,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 7,
+          fontSize: 12,
+          color: colors.TEXT_MUTED,
+        }}
+      >
+        <InfoCircleOutlined style={{ color: colors.ACCENT_BLUE, fontSize: 13 }} />
+        <span title="Delivery is outbound HTTPS only — Slack never needs to reach back to this proxy, so it works on private/internal instances.">
+          No OAuth — just paste a credential. Works on private / internal instances.
+        </span>
+      </div>
 
       {errors.length > 0 && (
-        <Alert
-          type="error"
-          showIcon
-          style={{ marginTop: 12 }}
-          message="Fix these before applying"
-          description={
-            <ul style={{ margin: 0, paddingLeft: 18 }}>
-              {errors.map((e, i) => (
-                <li key={i}>{e}</li>
-              ))}
-            </ul>
-          }
-        />
+        <div
+          style={{
+            marginTop: 10,
+            fontSize: 12,
+            color: colors.ACCENT_RED,
+            display: 'flex',
+            alignItems: 'flex-start',
+            gap: 7,
+          }}
+        >
+          <CloseCircleFilled style={{ marginTop: 2, fontSize: 13 }} />
+          <span>{errors.join(' · ')}</span>
+        </div>
       )}
 
       {/* Mode sub-toggle */}
@@ -248,7 +262,7 @@ export default function SlackConnectorCard({
           Create a Slack app →
         </a>
       </Text>
-    </div>
+    </>
   );
 }
 

--- a/demo/s3-browser/ui/src/components/SlackConnectorCard.tsx
+++ b/demo/s3-browser/ui/src/components/SlackConnectorCard.tsx
@@ -1,0 +1,606 @@
+/**
+ * SlackConnectorCard — the `format: slack` editor for `advanced.event_delivery`.
+ *
+ * Renders INSIDE WebhookDeliveryPanel and edits the SAME `useSectionEditor`
+ * value: the panel passes the live `form` down plus a `setField` patcher and the
+ * per-instance `nextId` row-id counter. There is NO parallel state mirror here
+ * (that's the documented admin-editor bug class) — every control reads from
+ * `form` and writes through `setField`, so discard / dirty-dot / ⌘S stay correct.
+ *
+ * ## Two delivery modes (mode is DERIVED, but the operator picks which to set up)
+ *
+ * - **Incoming Webhook** (no bot token): a `hooks.slack.com/services/…` URL bound
+ *   to one channel. Simplest; reuses the existing `webhook_urls` row editor.
+ * - **Bot token** (`xoxb-…` set): posts via the Slack Web API to `slack_channel`;
+ *   supports multiple channels + `@mentions`. Requires a channel.
+ *
+ * The mode toggle just clears/keeps the token so the derived backend mode follows
+ * what the operator is editing. The masked bot-token field mirrors the header
+ * secret UX: a server-masked token shows a "unchanged — type to replace"
+ * placeholder; typing unmasks it (`slackBotTokenMasked → false`).
+ *
+ * No tooltips/popovers (globally disabled in this layout) — native `title=`. No
+ * AntD Select popups (broken here) — checkboxes / Radio.Button only.
+ */
+import { useMemo } from 'react';
+import { Alert, Button, Checkbox, Input, Radio, Space, Typography } from 'antd';
+import { DeleteOutlined, PlusOutlined, SlackOutlined } from '@ant-design/icons';
+import { useColors } from '../ThemeContext';
+import { useCardStyles } from './shared-styles';
+import SectionHeader from './SectionHeader';
+import FormField from './FormField';
+import { AdvancedDisclosure } from './ruleEditorFields';
+import {
+  SLACK_NOTIFY_KINDS,
+  type WebhookFormState,
+  type WebhookUrlRow,
+  type SlackGlobRow,
+} from './webhookDeliveryPayload';
+
+const { Text } = Typography;
+
+/** Which mode the operator is currently editing — derived from token presence. */
+type SlackMode = 'webhook' | 'bot';
+
+interface Props {
+  form: WebhookFormState;
+  setField: (patch: Partial<WebhookFormState>) => void;
+  nextId: () => string;
+  /** Live validation errors that belong to the Slack card (shown inline). */
+  errors: string[];
+  inputRadius: React.CSSProperties;
+  /** Mutators for the shared webhook_urls rows (reused for the hooks.slack URL). */
+  updateUrl: (id: string, url: string) => void;
+  addUrl: () => void;
+  removeUrl: (id: string) => void;
+}
+
+const APP_LINK = 'https://api.slack.com/apps?new_app=1';
+
+export default function SlackConnectorCard({
+  form,
+  setField,
+  nextId,
+  errors,
+  inputRadius,
+  updateUrl,
+  addUrl,
+  removeUrl,
+}: Props) {
+  const { cardStyle } = useCardStyles();
+  const colors = useColors();
+
+  // Display mode = the operator's UI choice (sticky even with an empty token
+  // field). The BACKEND mode is derived from token presence at payload-build
+  // time — leaving webhook mode clears the token so the two stay consistent.
+  const mode: SlackMode = form.slackPreferBotMode ? 'bot' : 'webhook';
+
+  const setMode = (next: SlackMode) => {
+    if (next === mode) return;
+    if (next === 'webhook') {
+      // Leaving bot mode: drop the token so the backend resolves to webhook mode.
+      setField({ slackPreferBotMode: false, slackBotToken: '', slackBotTokenMasked: false });
+    } else {
+      // Enter bot mode; the token field below captures the xoxb- value.
+      setField({ slackPreferBotMode: true });
+    }
+  };
+
+  // ── Glob row mutators (stable-id keyed, never array index) ──
+  const updateGlob = (
+    key: 'slackIncludeRows' | 'slackExcludeRows',
+    id: string,
+    glob: string,
+  ) =>
+    setField({
+      [key]: form[key].map((r) => (r.id === id ? { ...r, glob } : r)),
+    } as Partial<WebhookFormState>);
+  const addGlob = (key: 'slackIncludeRows' | 'slackExcludeRows') =>
+    setField({
+      [key]: [...form[key], { id: nextId(), glob: '' } as SlackGlobRow],
+    } as Partial<WebhookFormState>);
+  const removeGlob = (key: 'slackIncludeRows' | 'slackExcludeRows', id: string) =>
+    setField({
+      [key]: form[key].filter((r) => r.id !== id),
+    } as Partial<WebhookFormState>);
+
+  const toggleKind = (kind: string, on: boolean) => {
+    const set = new Set(form.slackNotifyKinds);
+    if (on) set.add(kind);
+    else set.delete(kind);
+    // Preserve canonical ordering so the YAML diff stays stable.
+    setField({ slackNotifyKinds: SLACK_NOTIFY_KINDS.filter((k) => set.has(k)) });
+  };
+
+  return (
+    <div style={cardStyle}>
+      <SectionHeader
+        icon={<SlackOutlined />}
+        title="Slack connector"
+        description="Post object events to a Slack channel as a formatted message. No restart — applies live."
+      />
+
+      {/* No-OAuth callout */}
+      <Alert
+        type="info"
+        showIcon
+        style={{ marginTop: 16 }}
+        message="No OAuth needed — paste a credential."
+        description="Works on private / internal instances (outbound HTTPS only). Slack never needs to reach back to this proxy."
+      />
+
+      {errors.length > 0 && (
+        <Alert
+          type="error"
+          showIcon
+          style={{ marginTop: 12 }}
+          message="Fix these before applying"
+          description={
+            <ul style={{ margin: 0, paddingLeft: 18 }}>
+              {errors.map((e, i) => (
+                <li key={i}>{e}</li>
+              ))}
+            </ul>
+          }
+        />
+      )}
+
+      {/* Mode sub-toggle */}
+      <div style={{ marginTop: 16 }}>
+        <FormField
+          label="How to connect"
+          helpText="Incoming Webhook is the quickest. Use a bot token when you need multiple channels or @mentions."
+        >
+          <Radio.Group
+            value={mode}
+            onChange={(e) => setMode(e.target.value as SlackMode)}
+            style={{ display: 'flex', gap: 0 }}
+          >
+            <Radio.Button value="webhook" style={{ fontSize: 13 }} title="Post via a hooks.slack.com Incoming Webhook URL">
+              Incoming Webhook (simplest)
+            </Radio.Button>
+            <Radio.Button value="bot" style={{ fontSize: 13 }} title="Post via the Slack Web API with a bot token">
+              Bot token (multi-channel + @mentions)
+            </Radio.Button>
+          </Radio.Group>
+        </FormField>
+      </div>
+
+      {mode === 'webhook' ? (
+        <WebhookModeFields
+          form={form}
+          inputRadius={inputRadius}
+          updateUrl={updateUrl}
+          addUrl={addUrl}
+          removeUrl={removeUrl}
+          setField={setField}
+          colors={colors}
+        />
+      ) : (
+        <BotModeFields form={form} setField={setField} inputRadius={inputRadius} colors={colors} />
+      )}
+
+      {/* What gets posted */}
+      <AdvancedDisclosure title="What gets posted (event kinds + prefix filters)">
+        <FormField
+          label="Event kinds"
+          yamlPath="advanced.event_delivery.slack_notify_kinds"
+          helpText="Only these event kinds are posted to Slack. ObjectCreated is the default."
+        >
+          <Space direction="vertical" size={4} style={{ width: '100%' }}>
+            {SLACK_NOTIFY_KINDS.map((kind) => (
+              <Checkbox
+                key={kind}
+                checked={form.slackNotifyKinds.includes(kind)}
+                onChange={(e) => toggleKind(kind, e.target.checked)}
+              >
+                <span style={{ fontFamily: 'var(--font-mono)', fontSize: 13 }}>{kind}</span>
+              </Checkbox>
+            ))}
+          </Space>
+        </FormField>
+
+        <GlobRowsField
+          label="Include prefixes"
+          yamlPath="advanced.event_delivery.slack_include_globs"
+          helpText="Only keys matching at least one glob notify Slack. Empty = every key."
+          rows={form.slackIncludeRows}
+          onUpdate={(id, g) => updateGlob('slackIncludeRows', id, g)}
+          onAdd={() => addGlob('slackIncludeRows')}
+          onRemove={(id) => removeGlob('slackIncludeRows', id)}
+          inputRadius={inputRadius}
+          placeholder="releases/**"
+        />
+        <GlobRowsField
+          label="Exclude prefixes"
+          yamlPath="advanced.event_delivery.slack_exclude_globs"
+          helpText="Keys matching any of these are never posted (exclude wins over include)."
+          rows={form.slackExcludeRows}
+          onUpdate={(id, g) => updateGlob('slackExcludeRows', id, g)}
+          onAdd={() => addGlob('slackExcludeRows')}
+          onRemove={(id) => removeGlob('slackExcludeRows', id)}
+          inputRadius={inputRadius}
+          placeholder="tmp/**"
+        />
+      </AdvancedDisclosure>
+
+      {/* Live preview */}
+      <div style={{ marginTop: 20 }}>
+        <Text
+          type="secondary"
+          style={{
+            fontSize: 11,
+            fontWeight: 700,
+            letterSpacing: 0.5,
+            textTransform: 'uppercase',
+            display: 'block',
+            marginBottom: 8,
+          }}
+        >
+          Live preview — what lands in the channel
+        </Text>
+        <SlackPreview form={form} mode={mode} colors={colors} />
+      </div>
+
+      <Text type="secondary" style={{ fontSize: 11, display: 'block', marginTop: 12 }}>
+        Need an app?{' '}
+        <a href={APP_LINK} target="_blank" rel="noreferrer">
+          Create a Slack app →
+        </a>
+      </Text>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Mode-specific field groups
+// ─────────────────────────────────────────────────────────────────────────
+
+function MiniGuide({ steps }: { steps: string[] }) {
+  const { TEXT_MUTED, BORDER } = useColors();
+  return (
+    <ol
+      style={{
+        margin: '0 0 12px',
+        paddingLeft: 0,
+        listStyle: 'none',
+        counterReset: 'slk',
+        borderLeft: `2px solid ${BORDER}`,
+      }}
+    >
+      {steps.map((s, i) => (
+        <li
+          key={i}
+          style={{
+            counterIncrement: 'slk',
+            position: 'relative',
+            paddingLeft: 28,
+            marginBottom: 6,
+            fontSize: 12,
+            color: TEXT_MUTED,
+            lineHeight: 1.4,
+          }}
+        >
+          <span
+            aria-hidden="true"
+            style={{
+              position: 'absolute',
+              left: 8,
+              top: 0,
+              fontWeight: 700,
+              fontFamily: 'var(--font-mono)',
+            }}
+          >
+            {i + 1}.
+          </span>
+          {s}
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+function WebhookModeFields({
+  form,
+  inputRadius,
+  updateUrl,
+  addUrl,
+  removeUrl,
+  setField,
+  colors,
+}: {
+  form: WebhookFormState;
+  inputRadius: React.CSSProperties;
+  updateUrl: (id: string, url: string) => void;
+  addUrl: () => void;
+  removeUrl: (id: string) => void;
+  setField: (patch: Partial<WebhookFormState>) => void;
+  colors: ReturnType<typeof useColors>;
+}) {
+  return (
+    <div style={{ marginTop: 8 }}>
+      <MiniGuide
+        steps={[
+          'Create a Slack app (or open an existing one).',
+          'Enable “Incoming Webhooks” and add one for your channel.',
+          'Paste the hooks.slack.com webhook URL below.',
+        ]}
+      />
+      <FormField
+        label="Incoming Webhook URL"
+        yamlPath="advanced.event_delivery.webhook_urls"
+        helpText="The hooks.slack.com/services/… URL Slack generated. Each URL posts to its own bound channel."
+      >
+        <Space direction="vertical" style={{ width: '100%' }}>
+          {form.urlRows.length === 0 && (
+            <Text type="secondary" style={{ fontSize: 12 }}>
+              No webhook URL yet. Add the one Slack gave you.
+            </Text>
+          )}
+          {form.urlRows.map((row: WebhookUrlRow) => (
+            <Space.Compact key={row.id} style={{ width: '100%' }}>
+              <Input
+                value={row.url}
+                onChange={(e) => updateUrl(row.id, e.target.value)}
+                placeholder="https://hooks.slack.com/services/T000/B000/xxxx"
+                style={{ ...inputRadius, fontFamily: 'var(--font-mono)', fontSize: 13 }}
+              />
+              <Button
+                icon={<DeleteOutlined />}
+                onClick={() => removeUrl(row.id)}
+                title="Remove webhook URL"
+              />
+            </Space.Compact>
+          ))}
+          <Button icon={<PlusOutlined />} onClick={addUrl} size="small">
+            Add webhook URL
+          </Button>
+        </Space>
+      </FormField>
+
+      <FormField
+        label="Sender name (optional)"
+        yamlPath="advanced.event_delivery.slack_username"
+        helpText="Overrides the display name the message posts as. Webhook mode only."
+      >
+        <Input
+          value={form.slackUsername}
+          onChange={(e) => setField({ slackUsername: e.target.value })}
+          placeholder="DeltaGlider"
+          style={{ ...inputRadius, fontSize: 13, maxWidth: 280 }}
+        />
+      </FormField>
+
+      <FormField
+        label="Icon emoji (optional)"
+        yamlPath="advanced.event_delivery.slack_icon_emoji"
+        helpText="A Slack emoji shortcode used as the avatar, e.g. :package:. Webhook mode only."
+      >
+        <Input
+          value={form.slackIconEmoji}
+          onChange={(e) => setField({ slackIconEmoji: e.target.value })}
+          placeholder=":package:"
+          style={{ ...inputRadius, fontFamily: 'var(--font-mono)', fontSize: 13, maxWidth: 200, color: colors.TEXT_PRIMARY }}
+        />
+      </FormField>
+    </div>
+  );
+}
+
+function BotModeFields({
+  form,
+  setField,
+  inputRadius,
+  colors,
+}: {
+  form: WebhookFormState;
+  setField: (patch: Partial<WebhookFormState>) => void;
+  inputRadius: React.CSSProperties;
+  colors: ReturnType<typeof useColors>;
+}) {
+  return (
+    <div style={{ marginTop: 8 }}>
+      <MiniGuide
+        steps={[
+          'Create a Slack app (or open an existing one).',
+          'Add the chat:write and chat:write.public bot scopes.',
+          'Install the app to your workspace.',
+          'Paste the xoxb- bot token and the target channel below.',
+        ]}
+      />
+      <FormField
+        label="Bot token"
+        yamlPath="advanced.event_delivery.slack_bot_token"
+        helpText="The xoxb-… token from OAuth & Permissions. Stored encrypted and shown masked; leave it untouched to keep the current one."
+      >
+        <Input.Password
+          value={form.slackBotTokenMasked ? '' : form.slackBotToken}
+          onChange={(e) =>
+            // Typing unmasks: it's now a real, operator-entered value.
+            setField({ slackBotToken: e.target.value, slackBotTokenMasked: false })
+          }
+          placeholder={
+            form.slackBotTokenMasked
+              ? '•••••••• (unchanged — type to replace)'
+              : 'xoxb-…'
+          }
+          style={{ ...inputRadius, fontFamily: 'var(--font-mono)', fontSize: 13, maxWidth: 420, color: colors.TEXT_PRIMARY }}
+        />
+      </FormField>
+
+      <FormField
+        label="Channel"
+        yamlPath="advanced.event_delivery.slack_channel"
+        helpText="Channel id (like C0123ABC) or #name. Required in bot-token mode."
+      >
+        <Input
+          value={form.slackChannel}
+          onChange={(e) => setField({ slackChannel: e.target.value })}
+          placeholder="#deploys or C0123ABC"
+          style={{ ...inputRadius, fontFamily: 'var(--font-mono)', fontSize: 13, maxWidth: 280 }}
+        />
+      </FormField>
+    </div>
+  );
+}
+
+function GlobRowsField({
+  label,
+  yamlPath,
+  helpText,
+  rows,
+  onUpdate,
+  onAdd,
+  onRemove,
+  inputRadius,
+  placeholder,
+}: {
+  label: string;
+  yamlPath: string;
+  helpText: string;
+  rows: SlackGlobRow[];
+  onUpdate: (id: string, glob: string) => void;
+  onAdd: () => void;
+  onRemove: (id: string) => void;
+  inputRadius: React.CSSProperties;
+  placeholder: string;
+}) {
+  return (
+    <FormField label={label} yamlPath={yamlPath} helpText={helpText}>
+      <Space direction="vertical" style={{ width: '100%' }}>
+        {rows.length === 0 && (
+          <Text type="secondary" style={{ fontSize: 12 }}>
+            None.
+          </Text>
+        )}
+        {rows.map((row) => (
+          <Space.Compact key={row.id} style={{ width: '100%', maxWidth: 420 }}>
+            <Input
+              value={row.glob}
+              onChange={(e) => onUpdate(row.id, e.target.value)}
+              placeholder={placeholder}
+              style={{ ...inputRadius, fontFamily: 'var(--font-mono)', fontSize: 13 }}
+            />
+            <Button icon={<DeleteOutlined />} onClick={() => onRemove(row.id)} title="Remove glob" />
+          </Space.Compact>
+        ))}
+        <Button icon={<PlusOutlined />} onClick={onAdd} size="small">
+          Add prefix glob
+        </Button>
+      </Space>
+    </FormField>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Live faux-Slack preview — rendered purely client-side from current settings.
+// ─────────────────────────────────────────────────────────────────────────
+
+function SlackPreview({
+  form,
+  mode,
+  colors,
+}: {
+  form: WebhookFormState;
+  mode: SlackMode;
+  colors: ReturnType<typeof useColors>;
+}) {
+  // Slack's surfaces are always light; render a fixed light card so the preview
+  // reads as "this is what Slack shows", independent of the admin theme.
+  const appName =
+    mode === 'webhook' && form.slackUsername.trim() ? form.slackUsername.trim() : 'DeltaGlider';
+  const kind = form.slackNotifyKinds[0] ?? 'ObjectCreated';
+  const channelLabel = useMemo(() => {
+    if (mode === 'bot') {
+      const c = form.slackChannel.trim();
+      return c ? (c.startsWith('#') || c.startsWith('C') ? c : `#${c}`) : '#your-channel';
+    }
+    return 'webhook channel';
+  }, [mode, form.slackChannel]);
+
+  const verb =
+    kind === 'ObjectDeleted'
+      ? 'Deleted'
+      : kind === 'ObjectCopied' || kind === 'ReplicationObjectCopied'
+        ? 'Copied'
+        : kind === 'LifecycleExpired'
+          ? 'Expired'
+          : kind === 'LifecycleTransitioned'
+            ? 'Transitioned'
+            : 'New object';
+
+  return (
+    <div
+      style={{
+        background: '#ffffff',
+        border: `1px solid ${colors.BORDER}`,
+        borderRadius: 10,
+        padding: 14,
+        display: 'flex',
+        gap: 10,
+        fontFamily:
+          'Slack-Lato, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+        color: '#1d1c1d',
+        boxShadow: '0 1px 2px rgba(0,0,0,0.06)',
+      }}
+    >
+      {/* Avatar */}
+      <div
+        style={{
+          width: 36,
+          height: 36,
+          borderRadius: 8,
+          background: '#4a154b',
+          color: '#fff',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontSize: 18,
+          flexShrink: 0,
+        }}
+        aria-hidden="true"
+      >
+        📦
+      </div>
+      <div style={{ minWidth: 0, flex: 1 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 2 }}>
+          <span style={{ fontWeight: 700, fontSize: 13 }}>{appName}</span>
+          <span
+            style={{
+              fontSize: 10,
+              background: '#e8e8e8',
+              color: '#616061',
+              borderRadius: 3,
+              padding: '0 4px',
+              fontWeight: 700,
+            }}
+          >
+            APP
+          </span>
+          <span style={{ fontSize: 11, color: '#616061' }}>just now</span>
+        </div>
+        <div style={{ fontSize: 13, lineHeight: 1.45 }}>
+          <div style={{ fontWeight: 700, marginBottom: 2 }}>
+            📦 {verb} in <span style={{ color: '#1264a3' }}>{channelLabel}</span>
+          </div>
+          <div>
+            <span style={{ fontWeight: 700 }}>my-bucket</span>{' '}
+            <code
+              style={{
+                background: '#f6f6f6',
+                border: '1px solid #e0e0e0',
+                borderRadius: 3,
+                padding: '0 4px',
+                fontSize: 12,
+                color: '#c0392b',
+              }}
+            >
+              releases/app-v1.2.0.tar.gz
+            </code>
+          </div>
+          <div style={{ color: '#616061', fontSize: 12, marginTop: 2 }}>2.4 MB · application/gzip</div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/demo/s3-browser/ui/src/components/SlackConnectorCard.tsx
+++ b/demo/s3-browser/ui/src/components/SlackConnectorCard.tsx
@@ -305,34 +305,18 @@ export default function SlackConnectorCard({
         />
       </AdvancedDisclosure>
 
-      {/* Live preview */}
-      <div style={{ marginTop: 20 }}>
-        <Text
-          type="secondary"
-          style={{
-            fontSize: 11,
-            fontWeight: 700,
-            letterSpacing: 0.5,
-            textTransform: 'uppercase',
-            display: 'block',
-            marginBottom: 8,
-          }}
-        >
-          Live preview — what lands in the channel
-        </Text>
-        {mode === 'bot' && form.slackRoutes.length > 0 && (
-          <RoutingPreview
-            form={form}
-            colors={colors}
-            inputRadius={inputRadius}
-            sampleBucket={sampleBucket}
-            sampleKey={sampleKey}
-            onBucket={setSampleBucket}
-            onKey={setSampleKey}
-          />
-        )}
-        <SlackPreview form={form} mode={mode} colors={colors} />
-      </div>
+      {/* Live preview — ONE sample event drives both the resolved-channel chips
+          AND the faux Slack message, so they never tell contradictory stories. */}
+      <LivePreview
+        form={form}
+        mode={mode}
+        colors={colors}
+        inputRadius={inputRadius}
+        sampleBucket={sampleBucket}
+        sampleKey={sampleKey}
+        onBucket={setSampleBucket}
+        onKey={setSampleKey}
+      />
 
       <Text type="secondary" style={{ fontSize: 11, display: 'block', marginTop: 12 }}>
         Need an app?{' '}
@@ -718,8 +702,9 @@ function ChannelRoutingEditor({
 // channel; or nowhere). Best-effort client-side glob match.
 // ─────────────────────────────────────────────────────────────────────────
 
-function RoutingPreview({
+function LivePreview({
   form,
+  mode,
   colors,
   inputRadius,
   sampleBucket,
@@ -728,6 +713,7 @@ function RoutingPreview({
   onKey,
 }: {
   form: WebhookFormState;
+  mode: SlackMode;
   colors: ReturnType<typeof useColors>;
   inputRadius: React.CSSProperties;
   sampleBucket: string;
@@ -735,10 +721,30 @@ function RoutingPreview({
   onBucket: (v: string) => void;
   onKey: (v: string) => void;
 }) {
+  const routed = mode === 'bot' && form.slackRoutes.length > 0;
+
+  // Resolve the SAMPLE event to its channel(s) once — drives both the chips and
+  // the faux message below, so they always agree.
   const resolved = useMemo(
     () => resolveSlackChannelsPreview(form.slackRoutes, form.slackChannel, sampleBucket, sampleKey),
     [form.slackRoutes, form.slackChannel, sampleBucket, sampleKey],
   );
+
+  // The channel the faux message shows. In webhook mode the message goes to the
+  // webhook's bound channel; in bot mode it's the resolved channel(s) for the
+  // sample, the fallback (no routes), or "no channel" (routed but unmatched).
+  let messageChannels: string[];
+  if (mode === 'webhook') {
+    messageChannels = ['webhook channel'];
+  } else if (resolved.matches.length > 0) {
+    messageChannels = resolved.matches.map((m) => fmtChannel(m.channel));
+  } else if (resolved.fellBackToChannel) {
+    messageChannels = [fmtChannel(resolved.fallbackChannel)];
+  } else if (!routed) {
+    messageChannels = [fmtChannel(form.slackChannel) || '#your-channel'];
+  } else {
+    messageChannels = []; // routed but unmatched → posts nowhere
+  }
 
   const chipBase: React.CSSProperties = {
     fontFamily: 'var(--font-mono)',
@@ -749,55 +755,88 @@ function RoutingPreview({
   };
 
   return (
-    <div
-      style={{
-        marginBottom: 12,
-        padding: 12,
-        border: `1px dashed ${colors.BORDER}`,
-        borderRadius: 8,
-      }}
-    >
-      <Text style={{ fontSize: 12, color: colors.TEXT_MUTED, display: 'block', marginBottom: 8 }}>
-        Resolve a sample event:
+    <div style={{ marginTop: 20 }}>
+      <Text
+        type="secondary"
+        style={{
+          fontSize: 11,
+          fontWeight: 700,
+          letterSpacing: 0.5,
+          textTransform: 'uppercase',
+          display: 'block',
+          marginBottom: 8,
+        }}
+      >
+        Live preview — what lands in the channel
       </Text>
-      <Space.Compact style={{ width: '100%', maxWidth: 420, marginBottom: 10 }}>
-        <Input
-          value={sampleBucket}
-          onChange={(e) => onBucket(e.target.value)}
-          placeholder="bucket"
-          style={{ ...inputRadius, fontFamily: 'var(--font-mono)', fontSize: 13, maxWidth: 150 }}
-          title="Sample bucket"
-        />
-        <Input
-          value={sampleKey}
-          onChange={(e) => onKey(e.target.value)}
-          placeholder="path/to/key.zip"
-          style={{ ...inputRadius, fontFamily: 'var(--font-mono)', fontSize: 13 }}
-          title="Sample object key"
-        />
-      </Space.Compact>
-      <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap', fontSize: 13 }}>
-        <span style={{ color: colors.TEXT_MUTED }}>→</span>
-        {resolved.matches.length > 0 ? (
-          resolved.matches.map((m) => (
-            <span
-              key={m.channel}
-              style={{ ...chipBase, color: colors.ACCENT_BLUE }}
-              title={`Matched route: ${m.label}`}
-            >
-              {fmtChannel(m.channel)}
-            </span>
-          ))
-        ) : resolved.fellBackToChannel ? (
-          <span style={{ ...chipBase, color: colors.TEXT_SECONDARY }} title="No route matched — fallback channel">
-            (fallback) {fmtChannel(resolved.fallbackChannel)}
-          </span>
-        ) : (
-          <span style={{ ...chipBase, color: colors.TEXT_MUTED }} title="No route matched and no fallback channel set">
-            (no channel)
-          </span>
-        )}
-      </div>
+
+      {/* One sample event input (bot mode) → resolved-channel chips. */}
+      {mode === 'bot' && (
+        <div
+          style={{
+            marginBottom: 12,
+            padding: 12,
+            border: `1px dashed ${colors.BORDER}`,
+            borderRadius: 8,
+          }}
+        >
+          <Text style={{ fontSize: 12, color: colors.TEXT_MUTED, display: 'block', marginBottom: 8 }}>
+            Try a sample event{routed ? '' : ' (add routes to send buckets to different channels)'}:
+          </Text>
+          <Space.Compact style={{ width: '100%', maxWidth: 420, marginBottom: 10 }}>
+            <Input
+              value={sampleBucket}
+              onChange={(e) => onBucket(e.target.value)}
+              placeholder="bucket"
+              style={{ ...inputRadius, fontFamily: 'var(--font-mono)', fontSize: 13, maxWidth: 150 }}
+              title="Sample bucket"
+            />
+            <Input
+              value={sampleKey}
+              onChange={(e) => onKey(e.target.value)}
+              placeholder="path/to/key.zip"
+              style={{ ...inputRadius, fontFamily: 'var(--font-mono)', fontSize: 13 }}
+              title="Sample object key"
+            />
+          </Space.Compact>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap', fontSize: 13 }}>
+            <span style={{ color: colors.TEXT_MUTED }}>→</span>
+            {resolved.matches.length > 0 ? (
+              resolved.matches.map((m) => (
+                <span
+                  key={m.channel}
+                  style={{ ...chipBase, color: colors.ACCENT_BLUE }}
+                  title={`Matched route: ${m.label}`}
+                >
+                  {fmtChannel(m.channel)}
+                </span>
+              ))
+            ) : resolved.fellBackToChannel ? (
+              <span style={{ ...chipBase, color: colors.TEXT_SECONDARY }} title="No route matched — fallback channel">
+                (fallback) {fmtChannel(resolved.fallbackChannel)}
+              </span>
+            ) : routed ? (
+              <span style={{ ...chipBase, color: colors.ACCENT_RED }} title="No route matched and no fallback — this event would be posted NOWHERE">
+                (no channel — not posted)
+              </span>
+            ) : (
+              <span style={{ ...chipBase, color: colors.TEXT_SECONDARY }}>
+                {fmtChannel(form.slackChannel) || '#your-channel'}
+              </span>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* The faux Slack message — same sample + same resolved channel. */}
+      <SlackMessagePreview
+        form={form}
+        mode={mode}
+        colors={colors}
+        sampleBucket={sampleBucket || 'my-bucket'}
+        sampleKey={sampleKey || 'releases/app-v1.2.0.tar.gz'}
+        channels={messageChannels}
+      />
     </div>
   );
 }
@@ -813,27 +852,29 @@ function fmtChannel(c: string): string {
 // Live faux-Slack preview — rendered purely client-side from current settings.
 // ─────────────────────────────────────────────────────────────────────────
 
-function SlackPreview({
+function SlackMessagePreview({
   form,
   mode,
   colors,
+  sampleBucket,
+  sampleKey,
+  channels,
 }: {
   form: WebhookFormState;
   mode: SlackMode;
   colors: ReturnType<typeof useColors>;
+  sampleBucket: string;
+  sampleKey: string;
+  /** Resolved channel label(s) for the sample. Empty = posts nowhere. */
+  channels: string[];
 }) {
   // Slack's surfaces are always light; render a fixed light card so the preview
   // reads as "this is what Slack shows", independent of the admin theme.
   const appName =
     mode === 'webhook' && form.slackUsername.trim() ? form.slackUsername.trim() : 'DeltaGlider';
   const kind = form.slackNotifyKinds[0] ?? 'ObjectCreated';
-  const channelLabel = useMemo(() => {
-    if (mode === 'bot') {
-      const c = form.slackChannel.trim();
-      return c ? (c.startsWith('#') || c.startsWith('C') ? c : `#${c}`) : '#your-channel';
-    }
-    return 'webhook channel';
-  }, [mode, form.slackChannel]);
+  const channelLabel =
+    channels.length === 0 ? '(not posted)' : channels.join(', ');
 
   const verb =
     kind === 'ObjectDeleted'
@@ -901,7 +942,7 @@ function SlackPreview({
             📦 {verb} in <span style={{ color: '#1264a3' }}>{channelLabel}</span>
           </div>
           <div>
-            <span style={{ fontWeight: 700 }}>my-bucket</span>{' '}
+            <span style={{ fontWeight: 700 }}>{sampleBucket}</span>{' '}
             <code
               style={{
                 background: '#f6f6f6',
@@ -912,7 +953,7 @@ function SlackPreview({
                 color: '#c0392b',
               }}
             >
-              releases/app-v1.2.0.tar.gz
+              {sampleKey}
             </code>
           </div>
           <div style={{ color: '#616061', fontSize: 12, marginTop: 2 }}>2.4 MB · application/gzip</div>

--- a/demo/s3-browser/ui/src/components/SlackSetupGuide.tsx
+++ b/demo/s3-browser/ui/src/components/SlackSetupGuide.tsx
@@ -1,0 +1,427 @@
+/**
+ * SlackSetupGuide — an illustrated, step-by-step "how to create a Slack app"
+ * guide shown collapsibly inside the Slack connector.
+ *
+ * Two flows (webhook / bot token) share one StepCard primitive. The "mockups"
+ * are pure CSS/SVG fac-similes of the relevant Slack settings screens (NO
+ * external images — they'd break offline / under a strict CSP and could rot
+ * against Slack's real UI). They're deliberately schematic: enough to orient a
+ * first-time operator to where the button/toggle lives, not pixel-perfect.
+ *
+ * Copy-buttons surface the exact values the operator must paste into Slack
+ * (the scopes), so they don't have to transcribe them.
+ */
+import { useState } from 'react';
+import { Button, Typography, message } from 'antd';
+import {
+  CheckOutlined,
+  CopyOutlined,
+  DownOutlined,
+  RightOutlined,
+  SlackOutlined,
+} from '@ant-design/icons';
+import { useColors } from '../ThemeContext';
+
+const { Text } = Typography;
+
+const SLACK_APPS_URL = 'https://api.slack.com/apps?new_app=1';
+
+type Mode = 'webhook' | 'bot';
+
+export default function SlackSetupGuide({
+  mode,
+  defaultOpen,
+}: {
+  mode: Mode;
+  /** Open on first render (e.g. no token configured yet). */
+  defaultOpen: boolean;
+}) {
+  const c = useColors();
+  const [open, setOpen] = useState(defaultOpen);
+
+  return (
+    <div
+      style={{
+        border: `1px solid ${c.BORDER}`,
+        borderRadius: 10,
+        marginBottom: 16,
+        overflow: 'hidden',
+        background: c.BG_ELEVATED,
+      }}
+    >
+      <button
+        onClick={() => setOpen((o) => !o)}
+        style={{
+          width: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
+          padding: '10px 14px',
+          background: 'transparent',
+          border: 'none',
+          cursor: 'pointer',
+          color: c.TEXT_PRIMARY,
+          fontSize: 13,
+          fontWeight: 600,
+          textAlign: 'left',
+        }}
+        aria-expanded={open}
+      >
+        <SlackOutlined style={{ color: '#611f69', fontSize: 16 }} />
+        How to set up a Slack app
+        <span style={{ flex: 1 }} />
+        {open ? (
+          <DownOutlined style={{ fontSize: 11, color: c.TEXT_MUTED }} />
+        ) : (
+          <RightOutlined style={{ fontSize: 11, color: c.TEXT_MUTED }} />
+        )}
+      </button>
+
+      {open && (
+        <div style={{ padding: '4px 14px 16px' }}>
+          <Text style={{ fontSize: 12, color: c.TEXT_MUTED, display: 'block', marginBottom: 14 }}>
+            One-time, ~2 minutes. No OAuth callback — you create the app and paste a credential.
+          </Text>
+          {mode === 'webhook' ? <WebhookFlow c={c} /> : <BotFlow c={c} />}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Shared step card ─────────────────────────────────────────────────────────
+
+function StepCard({
+  n,
+  title,
+  children,
+  mockup,
+  c,
+}: {
+  n: number;
+  title: React.ReactNode;
+  children?: React.ReactNode;
+  mockup?: React.ReactNode;
+  c: ReturnType<typeof useColors>;
+}) {
+  return (
+    <div style={{ display: 'flex', gap: 12, marginBottom: 14 }}>
+      {/* Number column with connecting rail */}
+      <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+        <div
+          style={{
+            width: 26,
+            height: 26,
+            borderRadius: '50%',
+            background: c.ACCENT_BLUE,
+            color: '#fff',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            fontSize: 13,
+            fontWeight: 700,
+            flexShrink: 0,
+          }}
+        >
+          {n}
+        </div>
+        <div style={{ flex: 1, width: 2, background: c.BORDER, marginTop: 4 }} />
+      </div>
+      <div style={{ flex: 1, minWidth: 0, paddingBottom: 4 }}>
+        <div style={{ fontSize: 13, fontWeight: 600, color: c.TEXT_PRIMARY, marginBottom: 4 }}>
+          {title}
+        </div>
+        {children && (
+          <div style={{ fontSize: 12, color: c.TEXT_SECONDARY, lineHeight: 1.5 }}>{children}</div>
+        )}
+        {mockup && <div style={{ marginTop: 8 }}>{mockup}</div>}
+      </div>
+    </div>
+  );
+}
+
+function CopyChip({ value, c }: { value: string; c: ReturnType<typeof useColors> }) {
+  const [done, setDone] = useState(false);
+  return (
+    <button
+      onClick={() => {
+        navigator.clipboard?.writeText(value).then(
+          () => {
+            setDone(true);
+            message.success(`Copied ${value}`);
+            setTimeout(() => setDone(false), 1500);
+          },
+          () => message.error('Copy failed'),
+        );
+      }}
+      title={`Copy "${value}"`}
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 5,
+        fontFamily: 'var(--font-mono)',
+        fontSize: 12,
+        padding: '2px 8px',
+        borderRadius: 5,
+        border: `1px solid ${c.BORDER}`,
+        background: c.BG_CARD,
+        color: c.ACCENT_BLUE,
+        cursor: 'pointer',
+        marginRight: 6,
+        marginTop: 4,
+      }}
+    >
+      {value}
+      {done ? <CheckOutlined style={{ fontSize: 10 }} /> : <CopyOutlined style={{ fontSize: 10 }} />}
+    </button>
+  );
+}
+
+function CreateAppButton() {
+  return (
+    <a href={SLACK_APPS_URL} target="_blank" rel="noreferrer" style={{ display: 'inline-block', marginTop: 6 }}>
+      <Button size="small" icon={<SlackOutlined />}>
+        Open Slack app builder ↗
+      </Button>
+    </a>
+  );
+}
+
+// ── Faux Slack-UI mockups (schematic, CSS only) ──────────────────────────────
+
+/** A small framed "Slack settings screen" wrapper. */
+function SlackScreen({
+  title,
+  children,
+  c,
+}: {
+  title: string;
+  children: React.ReactNode;
+  c: ReturnType<typeof useColors>;
+}) {
+  return (
+    <div
+      style={{
+        border: `1px solid ${c.BORDER}`,
+        borderRadius: 8,
+        overflow: 'hidden',
+        maxWidth: 360,
+        background: '#fff',
+        color: '#1d1c1d',
+        fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+        boxShadow: '0 1px 3px rgba(0,0,0,0.08)',
+      }}
+    >
+      <div
+        style={{
+          background: '#3f0e40',
+          color: '#fff',
+          padding: '6px 10px',
+          fontSize: 11,
+          fontWeight: 600,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 6,
+        }}
+      >
+        <SlackOutlined style={{ fontSize: 12 }} /> {title}
+      </div>
+      <div style={{ padding: 10 }}>{children}</div>
+    </div>
+  );
+}
+
+function SlackBtn({ children, primary = true }: { children: React.ReactNode; primary?: boolean }) {
+  return (
+    <span
+      style={{
+        display: 'inline-block',
+        background: primary ? '#007a5a' : '#fff',
+        color: primary ? '#fff' : '#1d1c1d',
+        border: primary ? 'none' : '1px solid #ddd',
+        borderRadius: 4,
+        padding: '4px 12px',
+        fontSize: 12,
+        fontWeight: 700,
+      }}
+    >
+      {children}
+    </span>
+  );
+}
+
+function ScopeRow({ name }: { name: string }) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        padding: '5px 8px',
+        borderRadius: 4,
+        background: '#f8f8f8',
+        marginBottom: 4,
+        fontSize: 12,
+      }}
+    >
+      <code style={{ color: '#1264a3', fontWeight: 600 }}>{name}</code>
+      <span style={{ color: '#007a5a', fontSize: 11, fontWeight: 700 }}>+ Add</span>
+    </div>
+  );
+}
+
+function Toggle({ on = true }: { on?: boolean }) {
+  return (
+    <span
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        width: 34,
+        height: 18,
+        borderRadius: 10,
+        background: on ? '#007a5a' : '#ccc',
+        padding: 2,
+        justifyContent: on ? 'flex-end' : 'flex-start',
+      }}
+      aria-hidden="true"
+    >
+      <span style={{ width: 14, height: 14, borderRadius: '50%', background: '#fff' }} />
+    </span>
+  );
+}
+
+// ── The two flows ────────────────────────────────────────────────────────────
+
+function WebhookFlow({ c }: { c: ReturnType<typeof useColors> }) {
+  return (
+    <div>
+      <StepCard n={1} title="Create a Slack app" c={c}>
+        Go to the Slack app builder and click <b>Create New App → From scratch</b>. Name it (e.g.
+        “DeltaGlider”) and pick your workspace.
+        <div>
+          <CreateAppButton />
+        </div>
+        <SlackScreen title="Create an app" c={c}>
+          <div style={{ fontSize: 12, marginBottom: 8 }}>Pick a name &amp; workspace</div>
+          <div
+            style={{
+              border: '1px solid #ddd',
+              borderRadius: 4,
+              padding: '5px 8px',
+              fontSize: 12,
+              color: '#1d1c1d',
+              marginBottom: 8,
+            }}
+          >
+            DeltaGlider
+          </div>
+          <SlackBtn>Create App</SlackBtn>
+        </SlackScreen>
+      </StepCard>
+
+      <StepCard n={2} title="Enable Incoming Webhooks" c={c}>
+        In the left sidebar open <b>Incoming Webhooks</b> and flip <b>Activate Incoming Webhooks</b>{' '}
+        to On.
+        <SlackScreen title="Incoming Webhooks" c={c}>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              fontSize: 12,
+            }}
+          >
+            <span>Activate Incoming Webhooks</span>
+            <Toggle on />
+          </div>
+        </SlackScreen>
+      </StepCard>
+
+      <StepCard n={3} title="Add a webhook to a channel" c={c}>
+        Click <b>Add New Webhook to Workspace</b>, choose the channel to post to, and <b>Allow</b>.
+        Slack creates a webhook URL bound to that one channel.
+        <SlackScreen title="Add Webhook → choose channel" c={c}>
+          <div style={{ fontSize: 12, marginBottom: 8 }}>
+            Post to <code style={{ color: '#1264a3' }}>#deploys</code>
+          </div>
+          <SlackBtn>Allow</SlackBtn>
+        </SlackScreen>
+      </StepCard>
+
+      <StepCard
+        n={4}
+        title="Copy the Webhook URL → paste below"
+        c={c}
+      >
+        Copy the generated{' '}
+        <code style={{ color: c.ACCENT_BLUE }}>https://hooks.slack.com/services/…</code> URL and
+        paste it into the <b>Endpoints</b> field below. Done — that channel now gets your events.
+      </StepCard>
+    </div>
+  );
+}
+
+function BotFlow({ c }: { c: ReturnType<typeof useColors> }) {
+  return (
+    <div>
+      <StepCard n={1} title="Create a Slack app" c={c}>
+        Open the Slack app builder → <b>Create New App → From scratch</b>, name it, pick your
+        workspace.
+        <div>
+          <CreateAppButton />
+        </div>
+      </StepCard>
+
+      <StepCard n={2} title="Add bot token scopes" c={c}>
+        Open <b>OAuth &amp; Permissions</b> → under <b>Bot Token Scopes</b> add these two (copy them):
+        <div style={{ marginBottom: 4 }}>
+          <CopyChip value="chat:write" c={c} />
+          <CopyChip value="chat:write.public" c={c} />
+        </div>
+        <span style={{ fontSize: 11, color: c.TEXT_MUTED }}>
+          <code>chat:write.public</code> lets the bot post to any public channel without being
+          invited.
+        </span>
+        <SlackScreen title="OAuth &amp; Permissions → Bot Token Scopes" c={c}>
+          <ScopeRow name="chat:write" />
+          <ScopeRow name="chat:write.public" />
+        </SlackScreen>
+      </StepCard>
+
+      <StepCard n={3} title="Install to your workspace" c={c}>
+        Scroll up and click <b>Install to Workspace</b>, then <b>Allow</b>.
+        <SlackScreen title="OAuth &amp; Permissions" c={c}>
+          <SlackBtn>Install to Workspace</SlackBtn>
+        </SlackScreen>
+      </StepCard>
+
+      <StepCard n={4} title="Copy the Bot User OAuth Token → paste below" c={c}>
+        After installing, copy the <b>Bot User OAuth Token</b> (starts with{' '}
+        <code style={{ color: c.ACCENT_BLUE }}>xoxb-</code>) and paste it into <b>Bot token</b> below.
+        Then set the target <b>Channel</b> (a channel id like <code>C0123ABC</code> or{' '}
+        <code>#name</code>).
+        <SlackScreen title="OAuth Tokens for Your Workspace" c={c}>
+          <div style={{ fontSize: 11, color: '#616061', marginBottom: 4 }}>Bot User OAuth Token</div>
+          <div
+            style={{
+              fontFamily: 'monospace',
+              fontSize: 12,
+              background: '#f8f8f8',
+              border: '1px solid #ddd',
+              borderRadius: 4,
+              padding: '5px 8px',
+              color: '#1d1c1d',
+            }}
+          >
+            xoxb-2-•••••••••••••
+          </div>
+        </SlackScreen>
+      </StepCard>
+
+      <StepCard n={5} title="Invite the bot (only for PRIVATE channels)" c={c}>
+        Public channels work automatically via <code>chat:write.public</code>. For a <b>private</b>{' '}
+        channel, type <code>/invite @YourApp</code> in that channel once.
+      </StepCard>
+    </div>
+  );
+}

--- a/demo/s3-browser/ui/src/components/SlackSetupGuide.tsx
+++ b/demo/s3-browser/ui/src/components/SlackSetupGuide.tsx
@@ -1,6 +1,9 @@
 /**
  * SlackSetupGuide — an illustrated, step-by-step "how to create a Slack app"
- * guide shown collapsibly inside the Slack connector.
+ * guide. The CONTENT (step cards + schematic Slack mockups) now lives in
+ * `SlackSetupGuideContent`, which the connector card opens in a roomy AntD
+ * `Drawer` (`SlackSetupGuideDrawer`) instead of cramming it inline. At drawer
+ * width (~560px) the mockups finally have breathing room.
  *
  * Two flows (webhook / bot token) share one StepCard primitive. The "mockups"
  * are pure CSS/SVG fac-similes of the relevant Slack settings screens (NO
@@ -12,14 +15,8 @@
  * (the scopes), so they don't have to transcribe them.
  */
 import { useState } from 'react';
-import { Button, Typography, message } from 'antd';
-import {
-  CheckOutlined,
-  CopyOutlined,
-  DownOutlined,
-  RightOutlined,
-  SlackOutlined,
-} from '@ant-design/icons';
+import { Button, Drawer, Typography, message } from 'antd';
+import { CheckOutlined, CopyOutlined, SlackOutlined } from '@ant-design/icons';
 import { useColors } from '../ThemeContext';
 
 const { Text } = Typography;
@@ -28,64 +25,55 @@ const SLACK_APPS_URL = 'https://api.slack.com/apps?new_app=1';
 
 type Mode = 'webhook' | 'bot';
 
-export default function SlackSetupGuide({
+/**
+ * Roomy slide-in guide. The parent owns `open`/`onClose` (UI-only local state)
+ * and which `mode` to show; this just frames the step-by-step content with
+ * generous padding. At drawer width (~560px) the schematic Slack mockups
+ * finally have room — the whole point of moving them out of the inline column.
+ */
+export function SlackSetupGuideDrawer({
+  open,
   mode,
-  defaultOpen,
+  onClose,
 }: {
+  open: boolean;
   mode: Mode;
-  /** Open on first render (e.g. no token configured yet). */
-  defaultOpen: boolean;
+  onClose: () => void;
 }) {
   const c = useColors();
-  const [open, setOpen] = useState(defaultOpen);
-
   return (
-    <div
-      style={{
-        border: `1px solid ${c.BORDER}`,
-        borderRadius: 10,
-        marginBottom: 16,
-        overflow: 'hidden',
-        background: c.BG_ELEVATED,
-      }}
+    <Drawer
+      open={open}
+      onClose={onClose}
+      width={Math.min(640, typeof window !== 'undefined' ? window.innerWidth - 32 : 640)}
+      title={
+        <span style={{ display: 'inline-flex', alignItems: 'center', gap: 10, fontSize: 16 }}>
+          <SlackOutlined style={{ color: '#611f69', fontSize: 20 }} />
+          Set up a Slack app
+          <span
+            style={{
+              fontSize: 11,
+              fontWeight: 700,
+              letterSpacing: 0.5,
+              textTransform: 'uppercase',
+              color: c.TEXT_MUTED,
+              border: `1px solid ${c.BORDER}`,
+              borderRadius: 5,
+              padding: '1px 7px',
+            }}
+          >
+            {mode === 'webhook' ? 'Incoming Webhook' : 'Bot token'}
+          </span>
+        </span>
+      }
+      styles={{ body: { padding: '24px 28px 40px' } }}
     >
-      <button
-        onClick={() => setOpen((o) => !o)}
-        style={{
-          width: '100%',
-          display: 'flex',
-          alignItems: 'center',
-          gap: 8,
-          padding: '10px 14px',
-          background: 'transparent',
-          border: 'none',
-          cursor: 'pointer',
-          color: c.TEXT_PRIMARY,
-          fontSize: 13,
-          fontWeight: 600,
-          textAlign: 'left',
-        }}
-        aria-expanded={open}
-      >
-        <SlackOutlined style={{ color: '#611f69', fontSize: 16 }} />
-        How to set up a Slack app
-        <span style={{ flex: 1 }} />
-        {open ? (
-          <DownOutlined style={{ fontSize: 11, color: c.TEXT_MUTED }} />
-        ) : (
-          <RightOutlined style={{ fontSize: 11, color: c.TEXT_MUTED }} />
-        )}
-      </button>
-
-      {open && (
-        <div style={{ padding: '4px 14px 16px' }}>
-          <Text style={{ fontSize: 12, color: c.TEXT_MUTED, display: 'block', marginBottom: 14 }}>
-            One-time, ~2 minutes. No OAuth callback — you create the app and paste a credential.
-          </Text>
-          {mode === 'webhook' ? <WebhookFlow c={c} /> : <BotFlow c={c} />}
-        </div>
-      )}
-    </div>
+      <Text style={{ fontSize: 13, color: c.TEXT_MUTED, display: 'block', marginBottom: 24, lineHeight: 1.6 }}>
+        One-time, ~2 minutes. No OAuth callback — you create the app in Slack and paste a
+        credential back here. Nothing needs to reach this proxy.
+      </Text>
+      {mode === 'webhook' ? <WebhookFlow c={c} /> : <BotFlow c={c} />}
+    </Drawer>
   );
 }
 
@@ -105,36 +93,36 @@ function StepCard({
   c: ReturnType<typeof useColors>;
 }) {
   return (
-    <div style={{ display: 'flex', gap: 12, marginBottom: 14 }}>
+    <div style={{ display: 'flex', gap: 16, marginBottom: 24 }}>
       {/* Number column with connecting rail */}
       <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
         <div
           style={{
-            width: 26,
-            height: 26,
+            width: 30,
+            height: 30,
             borderRadius: '50%',
             background: c.ACCENT_BLUE,
             color: '#fff',
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',
-            fontSize: 13,
+            fontSize: 14,
             fontWeight: 700,
             flexShrink: 0,
           }}
         >
           {n}
         </div>
-        <div style={{ flex: 1, width: 2, background: c.BORDER, marginTop: 4 }} />
+        <div style={{ flex: 1, width: 2, background: c.BORDER, marginTop: 6 }} />
       </div>
       <div style={{ flex: 1, minWidth: 0, paddingBottom: 4 }}>
-        <div style={{ fontSize: 13, fontWeight: 600, color: c.TEXT_PRIMARY, marginBottom: 4 }}>
+        <div style={{ fontSize: 15, fontWeight: 600, color: c.TEXT_PRIMARY, marginBottom: 6 }}>
           {title}
         </div>
         {children && (
-          <div style={{ fontSize: 12, color: c.TEXT_SECONDARY, lineHeight: 1.5 }}>{children}</div>
+          <div style={{ fontSize: 13.5, color: c.TEXT_SECONDARY, lineHeight: 1.6 }}>{children}</div>
         )}
-        {mockup && <div style={{ marginTop: 8 }}>{mockup}</div>}
+        {mockup && <div style={{ marginTop: 12 }}>{mockup}</div>}
       </div>
     </div>
   );
@@ -158,17 +146,17 @@ function CopyChip({ value, c }: { value: string; c: ReturnType<typeof useColors>
       style={{
         display: 'inline-flex',
         alignItems: 'center',
-        gap: 5,
+        gap: 6,
         fontFamily: 'var(--font-mono)',
-        fontSize: 12,
-        padding: '2px 8px',
-        borderRadius: 5,
+        fontSize: 13,
+        padding: '4px 10px',
+        borderRadius: 6,
         border: `1px solid ${c.BORDER}`,
         background: c.BG_CARD,
         color: c.ACCENT_BLUE,
         cursor: 'pointer',
-        marginRight: 6,
-        marginTop: 4,
+        marginRight: 8,
+        marginTop: 6,
       }}
     >
       {value}
@@ -179,10 +167,8 @@ function CopyChip({ value, c }: { value: string; c: ReturnType<typeof useColors>
 
 function CreateAppButton() {
   return (
-    <a href={SLACK_APPS_URL} target="_blank" rel="noreferrer" style={{ display: 'inline-block', marginTop: 6 }}>
-      <Button size="small" icon={<SlackOutlined />}>
-        Open Slack app builder ↗
-      </Button>
+    <a href={SLACK_APPS_URL} target="_blank" rel="noreferrer" style={{ display: 'inline-block', marginTop: 10 }}>
+      <Button icon={<SlackOutlined />}>Open Slack app builder ↗</Button>
     </a>
   );
 }
@@ -205,7 +191,7 @@ function SlackScreen({
         border: `1px solid ${c.BORDER}`,
         borderRadius: 8,
         overflow: 'hidden',
-        maxWidth: 360,
+        maxWidth: 460,
         background: '#fff',
         color: '#1d1c1d',
         fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
@@ -216,17 +202,17 @@ function SlackScreen({
         style={{
           background: '#3f0e40',
           color: '#fff',
-          padding: '6px 10px',
-          fontSize: 11,
+          padding: '8px 14px',
+          fontSize: 12,
           fontWeight: 600,
           display: 'flex',
           alignItems: 'center',
-          gap: 6,
+          gap: 7,
         }}
       >
-        <SlackOutlined style={{ fontSize: 12 }} /> {title}
+        <SlackOutlined style={{ fontSize: 13 }} /> {title}
       </div>
-      <div style={{ padding: 10 }}>{children}</div>
+      <div style={{ padding: 14 }}>{children}</div>
     </div>
   );
 }
@@ -257,15 +243,15 @@ function ScopeRow({ name }: { name: string }) {
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'space-between',
-        padding: '5px 8px',
+        padding: '7px 10px',
         borderRadius: 4,
         background: '#f8f8f8',
-        marginBottom: 4,
-        fontSize: 12,
+        marginBottom: 6,
+        fontSize: 13,
       }}
     >
       <code style={{ color: '#1264a3', fontWeight: 600 }}>{name}</code>
-      <span style={{ color: '#007a5a', fontSize: 11, fontWeight: 700 }}>+ Add</span>
+      <span style={{ color: '#007a5a', fontSize: 12, fontWeight: 700 }}>+ Add</span>
     </div>
   );
 }

--- a/demo/s3-browser/ui/src/components/StickyDirtyBar.tsx
+++ b/demo/s3-browser/ui/src/components/StickyDirtyBar.tsx
@@ -21,6 +21,14 @@ interface Props {
   errorCount?: number;
   onDiscard: () => void;
   onApply: () => void;
+  /**
+   * When true, pin to the viewport bottom with `position: fixed` instead of
+   * `sticky`. Use this when the bar can't be rendered LAST in the scroll flow
+   * (e.g. a shared apply-rail rendered at the top of a panel). Sticky (default)
+   * is preferred when the bar IS the last child — it scopes to the scroll
+   * container and needs no layout assumptions.
+   */
+  floating?: boolean;
 }
 
 export default function StickyDirtyBar({
@@ -29,18 +37,33 @@ export default function StickyDirtyBar({
   errorCount = 0,
   onDiscard,
   onApply,
+  floating = false,
 }: Props) {
   const c = useColors();
   const hasErrors = errorCount > 0;
 
-  return (
-    <div
-      // Sticky so it pins to the bottom of the scroll viewport without taking a
-      // slot in the flow. pointer-events none on the wrapper lets clicks through
-      // the empty margins; the inner bar re-enables them.
-      style={{
+  const positionStyle: React.CSSProperties = floating
+    ? {
+        // Fixed to the viewport bottom-center. Anchored right of the sidebar
+        // isn't worth the complexity — centering reads fine over the content.
+        position: 'fixed',
+        left: 0,
+        right: 0,
+        bottom: 16,
+      }
+    : {
         position: 'sticky',
         bottom: 12,
+        height: visible ? 'auto' : 0,
+        marginTop: visible ? 8 : 0,
+      };
+
+  return (
+    <div
+      // pointer-events none on the wrapper lets clicks through the empty
+      // margins; the inner bar re-enables them.
+      style={{
+        ...positionStyle,
         zIndex: 20,
         display: 'flex',
         justifyContent: 'center',
@@ -49,9 +72,6 @@ export default function StickyDirtyBar({
         opacity: visible ? 1 : 0,
         transform: visible ? 'translateY(0)' : 'translateY(8px)',
         transition: 'opacity 160ms ease, transform 160ms ease',
-        // When hidden, collapse the sticky box so it never intercepts layout.
-        height: visible ? 'auto' : 0,
-        marginTop: visible ? 8 : 0,
       }}
       aria-hidden={!visible}
     >

--- a/demo/s3-browser/ui/src/components/StickyDirtyBar.tsx
+++ b/demo/s3-browser/ui/src/components/StickyDirtyBar.tsx
@@ -1,0 +1,105 @@
+/**
+ * StickyDirtyBar — a slim, bottom-pinned "unsaved changes" action bar.
+ *
+ * Replaces the bulky in-flow AntD `Alert` that pushed page content down when it
+ * appeared (layout shift). This bar is `position: sticky; bottom`, so it floats
+ * over the scroll viewport without displacing content, stays reachable while you
+ * scroll, and animates in/out subtly. The pattern admin UIs converge on
+ * (GitHub / Linear / Vercel settings bars).
+ *
+ * Renders nothing (and reserves no space) when not dirty — but because it's
+ * sticky/floating, its appearance never shifts the layout above it.
+ */
+import { Button, Space } from 'antd';
+import { ExclamationCircleFilled } from '@ant-design/icons';
+import { useColors } from '../ThemeContext';
+
+interface Props {
+  visible: boolean;
+  applying: boolean;
+  /** Number of blocking validation errors; Apply is disabled when > 0. */
+  errorCount?: number;
+  onDiscard: () => void;
+  onApply: () => void;
+}
+
+export default function StickyDirtyBar({
+  visible,
+  applying,
+  errorCount = 0,
+  onDiscard,
+  onApply,
+}: Props) {
+  const c = useColors();
+  const hasErrors = errorCount > 0;
+
+  return (
+    <div
+      // Sticky so it pins to the bottom of the scroll viewport without taking a
+      // slot in the flow. pointer-events none on the wrapper lets clicks through
+      // the empty margins; the inner bar re-enables them.
+      style={{
+        position: 'sticky',
+        bottom: 12,
+        zIndex: 20,
+        display: 'flex',
+        justifyContent: 'center',
+        pointerEvents: 'none',
+        // Subtle enter/leave: translate + fade, no reflow of siblings.
+        opacity: visible ? 1 : 0,
+        transform: visible ? 'translateY(0)' : 'translateY(8px)',
+        transition: 'opacity 160ms ease, transform 160ms ease',
+        // When hidden, collapse the sticky box so it never intercepts layout.
+        height: visible ? 'auto' : 0,
+        marginTop: visible ? 8 : 0,
+      }}
+      aria-hidden={!visible}
+    >
+      <div
+        style={{
+          pointerEvents: visible ? 'auto' : 'none',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 14,
+          padding: '8px 12px 8px 14px',
+          borderRadius: 12,
+          background: c.BG_ELEVATED,
+          border: `1px solid ${hasErrors ? c.ACCENT_RED : c.BORDER}`,
+          boxShadow: '0 8px 24px rgba(0,0,0,0.18)',
+          maxWidth: 560,
+        }}
+      >
+        <ExclamationCircleFilled
+          style={{ color: hasErrors ? c.ACCENT_RED : c.ACCENT_AMBER, fontSize: 15 }}
+        />
+        <span style={{ fontSize: 13, color: c.TEXT_PRIMARY, whiteSpace: 'nowrap' }}>
+          {hasErrors ? (
+            <span style={{ color: c.ACCENT_RED }}>
+              {errorCount} issue{errorCount === 1 ? '' : 's'} to fix
+            </span>
+          ) : (
+            <>
+              Unsaved changes
+              <span style={{ color: c.TEXT_MUTED }}> · applies live</span>
+            </>
+          )}
+        </span>
+        <Space size={8} style={{ marginLeft: 4 }}>
+          <Button size="small" onClick={onDiscard} disabled={applying}>
+            Discard
+          </Button>
+          <Button
+            type="primary"
+            size="small"
+            onClick={onApply}
+            disabled={applying || hasErrors}
+            loading={applying}
+            title={hasErrors ? 'Resolve the issues above before applying' : 'Apply changes'}
+          >
+            Apply
+          </Button>
+        </Space>
+      </div>
+    </div>
+  );
+}

--- a/demo/s3-browser/ui/src/components/TracePanel.tsx
+++ b/demo/s3-browser/ui/src/components/TracePanel.tsx
@@ -127,7 +127,7 @@ export default function TracePanel({ onSessionExpired }: Props) {
           title="Synthetic request"
           description="Evaluate the admission chain against a request shape of your choosing. No real traffic hits the backends — this is a dry-run against the live chain."
         />
-        <div style={{ marginTop: 16, display: 'flex', flexDirection: 'column', gap: 8 }}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
           <FormField label="Method" helpText="HTTP verb to trace.">
             <Radio.Group
               value={method}

--- a/demo/s3-browser/ui/src/components/UserForm.tsx
+++ b/demo/s3-browser/ui/src/components/UserForm.tsx
@@ -40,11 +40,18 @@ export default function UserForm({ user, onSaved, onDeleted, onCancel, onCreated
   const { inputRadius } = useCardStyles();
   const colors = useColors();
 
-  const [name, setName] = useState('');
-  const [accessKeyId, setAccessKeyId] = useState('');
+  // Initialize from `user` once. The form is remounted with a `key` per user
+  // (see render site), so a keyed remount resets all fields from these
+  // initializers — no prop→state sync effect (which was a redundant mirror).
+  const [name, setName] = useState(() => user?.name ?? '');
+  const [accessKeyId, setAccessKeyId] = useState(() => user?.access_key_id ?? '');
   const [secretKey, setSecretKey] = useState('');
-  const [enabled, setEnabled] = useState(true);
-  const [permissions, setPermissions] = useState<PermissionRow[]>([]);
+  const [enabled, setEnabled] = useState(() => user?.enabled ?? true);
+  const [permissions, setPermissions] = useState<PermissionRow[]>(() =>
+    user
+      ? permissionsToRows(user.permissions)
+      : [{ effect: 'Allow', actions: ['*'], resources: '*' }],
+  );
   const [saving, setSavingState] = useState(false);
   const [deleting, setDeletingState] = useState(false);
   const [error, setError] = useState('');
@@ -62,23 +69,6 @@ export default function UserForm({ user, onSaved, onDeleted, onCancel, onCreated
     getGroups().then(groups => setUserGroups(groups)).catch(() => {});
   }, []);
 
-  useEffect(() => {
-    if (user) {
-      setName(user.name);
-      setAccessKeyId(user.access_key_id);
-      setSecretKey('');
-      setEnabled(user.enabled);
-      setPermissions(permissionsToRows(user.permissions));
-    } else {
-      setName('');
-      setAccessKeyId('');
-      setSecretKey('');
-      setEnabled(true);
-      setPermissions([{ effect: 'Allow', actions: ['*'], resources: '*' }]);
-    }
-    setError('');
-    setSavedCredentials(null);
-  }, [user]);
 
   const handleSave = async () => {
     if (!name.trim()) { setError('Name is required'); return; }

--- a/demo/s3-browser/ui/src/components/UsersPanel.tsx
+++ b/demo/s3-browser/ui/src/components/UsersPanel.tsx
@@ -120,6 +120,7 @@ export default function UsersPanel({ onSessionExpired, onSavingChange, onNavigat
 
       {creating ? (
         <UserForm
+          key="new"
           user={null}
           onSaved={handleSaved}
           onCreated={handleCreated}

--- a/demo/s3-browser/ui/src/components/WebhookDeliveryPanel.tsx
+++ b/demo/s3-browser/ui/src/components/WebhookDeliveryPanel.tsx
@@ -37,6 +37,7 @@ import type { SectionApplyResponse } from '../adminApi';
 import { fetchEventOutbox } from '../adminApi';
 import { useCardStyles } from './shared-styles';
 import { useColors } from '../ThemeContext';
+import { useIsNarrow } from '../useIsNarrow';
 import { useSectionEditor } from '../useSectionEditor';
 import { useNavigation } from '../NavigationContext';
 import SectionHeader from './SectionHeader';
@@ -92,12 +93,15 @@ function PanelShell({ children }: { children: React.ReactNode }) {
   return (
     <div
       style={{
-        maxWidth: 740,
+        // Wide canvas: the Slack destination zone lays out as two columns
+        // (config + pinned preview) and needs the horizontal room. The generic
+        // config card up top still reads fine at this width.
+        maxWidth: 1180,
         margin: '0 auto',
-        padding: 'clamp(16px, 3vw, 24px)',
+        padding: 'clamp(20px, 3vw, 32px)',
         display: 'flex',
         flexDirection: 'column',
-        gap: 16,
+        gap: 24,
       }}
     >
       {children}
@@ -141,6 +145,8 @@ export default function WebhookDeliveryPanel({ onSessionExpired }: Props) {
   const { cardStyle, inputRadius } = useCardStyles();
   const colors = useColors();
   const nav = useNavigation();
+  // Below ~900px the Slack two-column (config + preview) split stacks vertically.
+  const isNarrow = useIsNarrow(900);
 
   // The connector ("destination") card is visually set apart from the generic
   // config above it: a teal accent on the left edge + a faintly tinted surface,
@@ -457,7 +463,7 @@ export default function WebhookDeliveryPanel({ onSessionExpired }: Props) {
               >
                 <Space direction="vertical" style={{ width: '100%' }}>
                   {form.urlRows.length === 0 && (
-                    <Text type="secondary" style={{ fontSize: 12 }}>
+                    <Text type="secondary" style={{ fontSize: 13 }}>
                       No endpoints. Add one to start delivering.
                     </Text>
                   )}
@@ -467,7 +473,7 @@ export default function WebhookDeliveryPanel({ onSessionExpired }: Props) {
                         value={row.url}
                         onChange={(e) => updateUrl(row.id, e.target.value)}
                         placeholder="https://hooks.example.com/deltaglider"
-                        style={{ ...inputRadius, fontFamily: 'var(--font-mono)', fontSize: 13 }}
+                        style={{ ...inputRadius, fontFamily: 'var(--font-mono)', fontSize: 14 }}
                       />
                       <Button
                         icon={<DeleteOutlined />}
@@ -489,7 +495,7 @@ export default function WebhookDeliveryPanel({ onSessionExpired }: Props) {
               >
                 <Space direction="vertical" style={{ width: '100%' }}>
                   {form.headerRows.length === 0 && (
-                    <Text type="secondary" style={{ fontSize: 12 }}>
+                    <Text type="secondary" style={{ fontSize: 13 }}>
                       No headers.
                     </Text>
                   )}
@@ -499,13 +505,13 @@ export default function WebhookDeliveryPanel({ onSessionExpired }: Props) {
                         value={row.name}
                         onChange={(e) => updateHeader(row.id, { name: e.target.value })}
                         placeholder="Authorization"
-                        style={{ ...inputRadius, fontFamily: 'var(--font-mono)', fontSize: 13, width: '40%' }}
+                        style={{ ...inputRadius, fontFamily: 'var(--font-mono)', fontSize: 14, width: '40%' }}
                       />
                       <Input
                         value={row.masked ? '' : row.value}
                         onChange={(e) => updateHeader(row.id, { value: e.target.value })}
                         placeholder={row.masked ? '•••••••• (unchanged — type to replace)' : 'Bearer …'}
-                        style={{ ...inputRadius, fontFamily: 'var(--font-mono)', fontSize: 13 }}
+                        style={{ ...inputRadius, fontFamily: 'var(--font-mono)', fontSize: 14 }}
                       />
                       <Button
                         icon={<DeleteOutlined />}
@@ -531,6 +537,7 @@ export default function WebhookDeliveryPanel({ onSessionExpired }: Props) {
             updateUrl={updateUrl}
             addUrl={addUrl}
             removeUrl={removeUrl}
+            isNarrow={isNarrow}
           />
         )}
       </div>
@@ -576,7 +583,7 @@ function DurationField(props: {
         value={props.value}
         onChange={(e) => props.onChange(e.target.value)}
         placeholder={props.placeholder}
-        style={{ ...props.inputRadius, fontFamily: 'var(--font-mono)', fontSize: 13, maxWidth: 160 }}
+        style={{ ...props.inputRadius, fontFamily: 'var(--font-mono)', fontSize: 14, maxWidth: 200 }}
       />
     </FormField>
   );
@@ -598,7 +605,7 @@ function NumberField(props: {
         min={props.min}
         max={props.max}
         onChange={(v) => props.onChange(typeof v === 'number' ? v : props.min)}
-        style={{ maxWidth: 160 }}
+        style={{ maxWidth: 200 }}
       />
     </FormField>
   );

--- a/demo/s3-browser/ui/src/components/WebhookDeliveryPanel.tsx
+++ b/demo/s3-browser/ui/src/components/WebhookDeliveryPanel.tsx
@@ -85,6 +85,7 @@ const EMPTY_FORM: WebhookFormState = {
   slackIncludeRows: [],
   slackExcludeRows: [],
   slackNotifyKinds: ['ObjectCreated'],
+  slackRoutes: [],
 };
 
 function PanelShell({ children }: { children: React.ReactNode }) {

--- a/demo/s3-browser/ui/src/components/WebhookDeliveryPanel.tsx
+++ b/demo/s3-browser/ui/src/components/WebhookDeliveryPanel.tsx
@@ -32,10 +32,11 @@ import {
   Tag,
   Typography,
 } from 'antd';
-import { DeleteOutlined, PlusOutlined, SendOutlined } from '@ant-design/icons';
+import { ApiOutlined, DeleteOutlined, PlusOutlined, SendOutlined } from '@ant-design/icons';
 import type { SectionApplyResponse } from '../adminApi';
 import { fetchEventOutbox } from '../adminApi';
 import { useCardStyles } from './shared-styles';
+import { useColors } from '../ThemeContext';
 import { useSectionEditor } from '../useSectionEditor';
 import { useNavigation } from '../NavigationContext';
 import SectionHeader from './SectionHeader';
@@ -43,6 +44,7 @@ import FormField from './FormField';
 import ApplyDialog from './ApplyDialog';
 import { AdvancedDisclosure } from './ruleEditorFields';
 import SlackConnectorCard from './SlackConnectorCard';
+import StickyDirtyBar from './StickyDirtyBar';
 import {
   formFromWire,
   buildPayloadFromForm,
@@ -102,9 +104,51 @@ function PanelShell({ children }: { children: React.ReactNode }) {
   );
 }
 
+/** A labeled section divider: a hairline rule with a centered uppercase label,
+ *  marking the visual transition from generic config to the connector zone. */
+function ConnectorDivider({ label }: { label: string }) {
+  const c = useColors();
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 12,
+        margin: '4px 2px',
+        userSelect: 'none',
+      }}
+    >
+      <div style={{ flex: 1, height: 1, background: c.BORDER }} />
+      <span
+        style={{
+          fontSize: 11,
+          fontWeight: 700,
+          letterSpacing: 1,
+          textTransform: 'uppercase',
+          color: c.TEXT_MUTED,
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {label}
+      </span>
+      <div style={{ flex: 1, height: 1, background: c.BORDER }} />
+    </div>
+  );
+}
+
 export default function WebhookDeliveryPanel({ onSessionExpired }: Props) {
   const { cardStyle, inputRadius } = useCardStyles();
+  const colors = useColors();
   const nav = useNavigation();
+
+  // The connector ("destination") card is visually set apart from the generic
+  // config above it: a teal accent on the left edge + a faintly tinted surface,
+  // so the eye reads "this is where events go" as a distinct zone.
+  const connectorCardStyle: React.CSSProperties = {
+    ...cardStyle,
+    borderLeft: `3px solid ${colors.ACCENT_BLUE}`,
+    background: `linear-gradient(${colors.BG_CARD}, ${colors.BG_CARD}) padding-box`,
+  };
 
   // Per-instance row-id counter (no module global) — only used for React keys
   // within this panel instance.
@@ -220,45 +264,20 @@ export default function WebhookDeliveryPanel({ onSessionExpired }: Props) {
 
   return (
     <PanelShell>
-      {isDirty && (
-        <Alert
-          type="warning"
-          showIcon
-          message="Unsaved changes to webhook delivery"
-          description="Review the diff in the Apply dialog before persisting. Changes apply live — no restart."
-          action={
-            <Space>
-              <Button size="small" onClick={discard} disabled={applying}>
-                Discard
-              </Button>
-              <Button
-                type="primary"
-                size="small"
-                onClick={runApply}
-                disabled={applying || liveErrors.length > 0}
-                loading={applying}
-              >
-                Apply
-              </Button>
-            </Space>
-          }
-        />
-      )}
-
-      {/* Raw-mode errors surface here; Slack-mode errors render inline in the
-          connector card (single surface either way — no duplication). */}
+      {/* Raw-mode errors surface here, compactly; Slack-mode errors render
+          inline in the connector card. The sticky bar below carries the count +
+          actions so this block staying mounted (min-height) avoids layout shift. */}
       {form.format === 'raw' && liveErrors.length > 0 && (
         <Alert
           type="error"
           showIcon
-          message="Fix these before applying"
-          description={
-            <ul style={{ margin: 0, paddingLeft: 18 }}>
-              {liveErrors.map((e, i) => (
-                <li key={i}>{e}</li>
-              ))}
-            </ul>
+          banner
+          message={
+            <span style={{ fontSize: 13 }}>
+              {liveErrors.join(' · ')}
+            </span>
           }
+          style={{ borderRadius: 8 }}
         />
       )}
 
@@ -289,12 +308,12 @@ export default function WebhookDeliveryPanel({ onSessionExpired }: Props) {
         />
       )}
 
-      {/* Master switch + format selector */}
+      {/* ── 1. GENERIC DELIVERY CONFIG (all format-agnostic settings together) ── */}
       <div style={cardStyle}>
         <SectionHeader
           icon={<SendOutlined />}
           title="Event delivery"
-          description="Deliver durable object events (create/delete/copy) downstream. The outbox accrues events even while disabled — they deliver once you enable + configure a destination."
+          description="Deliver durable object events (create/delete/copy) downstream. The outbox accrues events even while disabled — they deliver once you enable + configure a destination below."
         />
         <div style={{ marginTop: 16 }}>
           <FormField label="Enable delivery" yamlPath="advanced.event_delivery.enabled">
@@ -319,15 +338,121 @@ export default function WebhookDeliveryPanel({ onSessionExpired }: Props) {
               </Radio.Button>
             </Radio.Group>
           </FormField>
+        </div>
 
-          {/* Raw mode: endpoints + headers. Slack mode hides these — headers
-              don't apply to the Slack connector. */}
-          {form.format === 'raw' && (
-            <>
+        {/* Generic delivery tuning lives WITH the rest of the generic config —
+            it's format-agnostic (applies to raw + Slack alike). */}
+        <div style={{ marginTop: 8 }}>
+          <AdvancedDisclosure title="Delivery tuning (retry, retention, batching)">
+            <DurationField
+              label="Tick interval"
+              yamlPath="advanced.event_delivery.tick_interval"
+              help="How often the dispatcher wakes to deliver due events."
+              value={form.tick_interval}
+              placeholder="10s"
+              onChange={(v) => setField({ tick_interval: v })}
+              inputRadius={inputRadius}
+            />
+            <NumberField
+              label="Batch size"
+              yamlPath="advanced.event_delivery.batch_size"
+              help="Max events claimed per tick (clamped 1–500)."
+              value={form.batch_size}
+              min={1}
+              max={500}
+              onChange={(v) => setField({ batch_size: v })}
+            />
+            <DurationField
+              label="Request timeout"
+              yamlPath="advanced.event_delivery.request_timeout"
+              help="Per-endpoint HTTP timeout."
+              value={form.request_timeout}
+              placeholder="5s"
+              onChange={(v) => setField({ request_timeout: v })}
+              inputRadius={inputRadius}
+            />
+            <NumberField
+              label="Max attempts"
+              yamlPath="advanced.event_delivery.max_attempts"
+              help="Attempts before an event becomes permanently failed."
+              value={form.max_attempts}
+              min={1}
+              onChange={(v) => setField({ max_attempts: v })}
+            />
+            <DurationField
+              label="Retry base"
+              yamlPath="advanced.event_delivery.retry_base"
+              help="Initial retry delay; exponential backoff doubles it per attempt."
+              value={form.retry_base}
+              placeholder="5s"
+              onChange={(v) => setField({ retry_base: v })}
+              inputRadius={inputRadius}
+            />
+            <DurationField
+              label="Retry max"
+              yamlPath="advanced.event_delivery.retry_max"
+              help="Ceiling for the backoff delay."
+              value={form.retry_max}
+              placeholder="5m"
+              onChange={(v) => setField({ retry_max: v })}
+              inputRadius={inputRadius}
+            />
+            <DurationField
+              label="Stale claim after"
+              yamlPath="advanced.event_delivery.stale_claim_after"
+              help="In-progress claims older than this are reclaimable (crash recovery)."
+              value={form.stale_claim_after}
+              placeholder="60s"
+              onChange={(v) => setField({ stale_claim_after: v })}
+              inputRadius={inputRadius}
+            />
+            <DurationField
+              label="Delivered retention"
+              yamlPath="advanced.event_delivery.delivered_retention"
+              help="Delivered rows older than this are pruned. 0s keeps them until manually pruned."
+              value={form.delivered_retention}
+              placeholder="24h"
+              onChange={(v) => setField({ delivered_retention: v })}
+              inputRadius={inputRadius}
+            />
+            <NumberField
+              label="Delivered max rows"
+              yamlPath="advanced.event_delivery.delivered_max_rows"
+              help="Cap on retained delivered rows (pending/failed never pruned by this)."
+              value={form.delivered_max_rows}
+              min={0}
+              onChange={(v) => setField({ delivered_max_rows: v })}
+            />
+            <NumberField
+              label="Prune batch"
+              yamlPath="advanced.event_delivery.prune_batch"
+              help="Max delivered rows pruned per tick."
+              value={form.prune_batch}
+              min={0}
+              onChange={(v) => setField({ prune_batch: v })}
+            />
+          </AdvancedDisclosure>
+        </div>
+      </div>
+
+      {/* ── 2. DESTINATION ZONE — labeled divider sets the connector apart ── */}
+      <ConnectorDivider label={form.format === 'slack' ? 'Slack destination' : 'Webhook destination'} />
+
+      {/* The connector card carries an accent left-border so it reads as a
+          distinct "where does it go" zone, separate from the generic config. */}
+      <div style={connectorCardStyle}>
+        {form.format === 'raw' ? (
+          <>
+            <SectionHeader
+              icon={<ApiOutlined />}
+              title="Raw webhook destination"
+              description="POST the deltaglider.event.v1 JSON envelope to one or more HTTP endpoints with optional static headers."
+            />
+            <div style={{ marginTop: 16 }}>
               <FormField
                 label="Endpoints"
                 yamlPath="advanced.event_delivery.webhook_urls"
-                helpText="HTTP(S) URLs that receive a deltaglider.event.v1 JSON payload. An event is marked delivered only after every endpoint returns 2xx."
+                helpText="HTTP(S) URLs that receive the payload. An event is marked delivered only after every endpoint returns 2xx."
               >
                 <Space direction="vertical" style={{ width: '100%' }}>
                   {form.urlRows.length === 0 && (
@@ -393,116 +518,20 @@ export default function WebhookDeliveryPanel({ onSessionExpired }: Props) {
                   </Button>
                 </Space>
               </FormField>
-            </>
-          )}
-        </div>
-      </div>
-
-      {/* Slack connector — edits the SAME form value (single source of truth). */}
-      {form.format === 'slack' && (
-        <SlackConnectorCard
-          form={form}
-          setField={setField}
-          nextId={nextId}
-          errors={liveErrors}
-          inputRadius={inputRadius}
-          updateUrl={updateUrl}
-          addUrl={addUrl}
-          removeUrl={removeUrl}
-        />
-      )}
-
-      {/* Advanced tuning */}
-      <div style={cardStyle}>
-        <AdvancedDisclosure title="Delivery tuning (retry, retention, batching)">
-          <DurationField
-            label="Tick interval"
-            yamlPath="advanced.event_delivery.tick_interval"
-            help="How often the dispatcher wakes to deliver due events."
-            value={form.tick_interval}
-            placeholder="10s"
-            onChange={(v) => setField({ tick_interval: v })}
+            </div>
+          </>
+        ) : (
+          <SlackConnectorCard
+            form={form}
+            setField={setField}
+            nextId={nextId}
+            errors={liveErrors}
             inputRadius={inputRadius}
+            updateUrl={updateUrl}
+            addUrl={addUrl}
+            removeUrl={removeUrl}
           />
-          <NumberField
-            label="Batch size"
-            yamlPath="advanced.event_delivery.batch_size"
-            help="Max events claimed per tick (clamped 1–500)."
-            value={form.batch_size}
-            min={1}
-            max={500}
-            onChange={(v) => setField({ batch_size: v })}
-          />
-          <DurationField
-            label="Request timeout"
-            yamlPath="advanced.event_delivery.request_timeout"
-            help="Per-endpoint HTTP timeout."
-            value={form.request_timeout}
-            placeholder="5s"
-            onChange={(v) => setField({ request_timeout: v })}
-            inputRadius={inputRadius}
-          />
-          <NumberField
-            label="Max attempts"
-            yamlPath="advanced.event_delivery.max_attempts"
-            help="Attempts before an event becomes permanently failed."
-            value={form.max_attempts}
-            min={1}
-            onChange={(v) => setField({ max_attempts: v })}
-          />
-          <DurationField
-            label="Retry base"
-            yamlPath="advanced.event_delivery.retry_base"
-            help="Initial retry delay; exponential backoff doubles it per attempt."
-            value={form.retry_base}
-            placeholder="5s"
-            onChange={(v) => setField({ retry_base: v })}
-            inputRadius={inputRadius}
-          />
-          <DurationField
-            label="Retry max"
-            yamlPath="advanced.event_delivery.retry_max"
-            help="Ceiling for the backoff delay."
-            value={form.retry_max}
-            placeholder="5m"
-            onChange={(v) => setField({ retry_max: v })}
-            inputRadius={inputRadius}
-          />
-          <DurationField
-            label="Stale claim after"
-            yamlPath="advanced.event_delivery.stale_claim_after"
-            help="In-progress claims older than this are reclaimable (crash recovery)."
-            value={form.stale_claim_after}
-            placeholder="60s"
-            onChange={(v) => setField({ stale_claim_after: v })}
-            inputRadius={inputRadius}
-          />
-          <DurationField
-            label="Delivered retention"
-            yamlPath="advanced.event_delivery.delivered_retention"
-            help="Delivered rows older than this are pruned. 0s keeps them until manually pruned."
-            value={form.delivered_retention}
-            placeholder="24h"
-            onChange={(v) => setField({ delivered_retention: v })}
-            inputRadius={inputRadius}
-          />
-          <NumberField
-            label="Delivered max rows"
-            yamlPath="advanced.event_delivery.delivered_max_rows"
-            help="Cap on retained delivered rows (pending/failed never pruned by this)."
-            value={form.delivered_max_rows}
-            min={0}
-            onChange={(v) => setField({ delivered_max_rows: v })}
-          />
-          <NumberField
-            label="Prune batch"
-            yamlPath="advanced.event_delivery.prune_batch"
-            help="Max delivered rows pruned per tick."
-            value={form.prune_batch}
-            min={0}
-            onChange={(v) => setField({ prune_batch: v })}
-          />
-        </AdvancedDisclosure>
+        )}
       </div>
 
       <ApplyDialog
@@ -512,6 +541,16 @@ export default function WebhookDeliveryPanel({ onSessionExpired }: Props) {
         onApply={confirmApply}
         onCancel={cancelApply}
         loading={applying}
+      />
+
+      {/* Slim floating action bar — pins to the bottom of the scroll viewport,
+          never displaces content above it. */}
+      <StickyDirtyBar
+        visible={isDirty}
+        applying={applying}
+        errorCount={liveErrors.length}
+        onDiscard={discard}
+        onApply={runApply}
       />
     </PanelShell>
   );

--- a/demo/s3-browser/ui/src/components/WebhookDeliveryPanel.tsx
+++ b/demo/s3-browser/ui/src/components/WebhookDeliveryPanel.tsx
@@ -322,7 +322,7 @@ export default function WebhookDeliveryPanel({ onSessionExpired }: Props) {
           title="Event delivery"
           description="Deliver durable object events (create/delete/copy) downstream. The outbox accrues events even while disabled — they deliver once you enable + configure a destination below."
         />
-        <div style={{ marginTop: 16 }}>
+        <div>
           <FormField label="Enable delivery" yamlPath="advanced.event_delivery.enabled">
             <Switch checked={form.enabled} onChange={(v) => setField({ enabled: v })} />
           </FormField>
@@ -455,7 +455,7 @@ export default function WebhookDeliveryPanel({ onSessionExpired }: Props) {
               title="Raw webhook destination"
               description="POST the deltaglider.event.v1 JSON envelope to one or more HTTP endpoints with optional static headers."
             />
-            <div style={{ marginTop: 16 }}>
+            <div>
               <FormField
                 label="Endpoints"
                 yamlPath="advanced.event_delivery.webhook_urls"

--- a/demo/s3-browser/ui/src/components/WebhookDeliveryPanel.tsx
+++ b/demo/s3-browser/ui/src/components/WebhookDeliveryPanel.tsx
@@ -26,6 +26,7 @@ import {
   Button,
   Input,
   InputNumber,
+  Radio,
   Space,
   Switch,
   Tag,
@@ -41,6 +42,7 @@ import SectionHeader from './SectionHeader';
 import FormField from './FormField';
 import ApplyDialog from './ApplyDialog';
 import { AdvancedDisclosure } from './ruleEditorFields';
+import SlackConnectorCard from './SlackConnectorCard';
 import {
   formFromWire,
   buildPayloadFromForm,
@@ -71,6 +73,16 @@ const EMPTY_FORM: WebhookFormState = {
   delivered_retention: '24h',
   delivered_max_rows: 10000,
   prune_batch: 100,
+  format: 'raw',
+  slackPreferBotMode: false,
+  slackBotToken: '',
+  slackBotTokenMasked: false,
+  slackChannel: '',
+  slackUsername: '',
+  slackIconEmoji: '',
+  slackIncludeRows: [],
+  slackExcludeRows: [],
+  slackNotifyKinds: ['ObjectCreated'],
 };
 
 function PanelShell({ children }: { children: React.ReactNode }) {
@@ -233,7 +245,9 @@ export default function WebhookDeliveryPanel({ onSessionExpired }: Props) {
         />
       )}
 
-      {liveErrors.length > 0 && (
+      {/* Raw-mode errors surface here; Slack-mode errors render inline in the
+          connector card (single surface either way — no duplication). */}
+      {form.format === 'raw' && liveErrors.length > 0 && (
         <Alert
           type="error"
           showIcon
@@ -275,12 +289,12 @@ export default function WebhookDeliveryPanel({ onSessionExpired }: Props) {
         />
       )}
 
-      {/* Master switch + endpoints */}
+      {/* Master switch + format selector */}
       <div style={cardStyle}>
         <SectionHeader
           icon={<SendOutlined />}
-          title="Webhook delivery"
-          description="Deliver durable object events (create/delete/copy) to HTTP endpoints. The outbox accrues events even while disabled — they deliver once you enable + add an endpoint."
+          title="Event delivery"
+          description="Deliver durable object events (create/delete/copy) downstream. The outbox accrues events even while disabled — they deliver once you enable + configure a destination."
         />
         <div style={{ marginTop: 16 }}>
           <FormField label="Enable delivery" yamlPath="advanced.event_delivery.enabled">
@@ -288,76 +302,115 @@ export default function WebhookDeliveryPanel({ onSessionExpired }: Props) {
           </FormField>
 
           <FormField
-            label="Endpoints"
-            yamlPath="advanced.event_delivery.webhook_urls"
-            helpText="HTTP(S) URLs that receive a deltaglider.event.v1 JSON payload. An event is marked delivered only after every endpoint returns 2xx."
+            label="Payload format"
+            yamlPath="advanced.event_delivery.format"
+            helpText="Raw posts the deltaglider.event.v1 JSON envelope to your endpoints. Slack formats each event as a chat message."
           >
-            <Space direction="vertical" style={{ width: '100%' }}>
-              {form.urlRows.length === 0 && (
-                <Text type="secondary" style={{ fontSize: 12 }}>
-                  No endpoints. Add one to start delivering.
-                </Text>
-              )}
-              {form.urlRows.map((row) => (
-                <Space.Compact key={row.id} style={{ width: '100%' }}>
-                  <Input
-                    value={row.url}
-                    onChange={(e) => updateUrl(row.id, e.target.value)}
-                    placeholder="https://hooks.example.com/deltaglider"
-                    style={{ ...inputRadius, fontFamily: 'var(--font-mono)', fontSize: 13 }}
-                  />
-                  <Button
-                    icon={<DeleteOutlined />}
-                    onClick={() => removeUrl(row.id)}
-                    title="Remove endpoint"
-                  />
-                </Space.Compact>
-              ))}
-              <Button icon={<PlusOutlined />} onClick={addUrl} size="small">
-                Add endpoint
-              </Button>
-            </Space>
+            <Radio.Group
+              value={form.format}
+              onChange={(e) => setField({ format: e.target.value as 'raw' | 'slack' })}
+              style={{ display: 'flex', gap: 0 }}
+            >
+              <Radio.Button value="raw" style={{ fontSize: 13 }} title="Raw JSON webhook payload">
+                Raw webhook
+              </Radio.Button>
+              <Radio.Button value="slack" style={{ fontSize: 13 }} title="Format events as Slack messages">
+                Slack
+              </Radio.Button>
+            </Radio.Group>
           </FormField>
 
-          <FormField
-            label="Headers"
-            yamlPath="advanced.event_delivery.webhook_headers"
-            helpText="Static headers sent with every request — e.g. an Authorization bearer token. Values are stored encrypted and shown masked; leave a masked value untouched to keep it."
-          >
-            <Space direction="vertical" style={{ width: '100%' }}>
-              {form.headerRows.length === 0 && (
-                <Text type="secondary" style={{ fontSize: 12 }}>
-                  No headers.
-                </Text>
-              )}
-              {form.headerRows.map((row) => (
-                <Space.Compact key={row.id} style={{ width: '100%' }}>
-                  <Input
-                    value={row.name}
-                    onChange={(e) => updateHeader(row.id, { name: e.target.value })}
-                    placeholder="Authorization"
-                    style={{ ...inputRadius, fontFamily: 'var(--font-mono)', fontSize: 13, width: '40%' }}
-                  />
-                  <Input
-                    value={row.masked ? '' : row.value}
-                    onChange={(e) => updateHeader(row.id, { value: e.target.value })}
-                    placeholder={row.masked ? '•••••••• (unchanged — type to replace)' : 'Bearer …'}
-                    style={{ ...inputRadius, fontFamily: 'var(--font-mono)', fontSize: 13 }}
-                  />
-                  <Button
-                    icon={<DeleteOutlined />}
-                    onClick={() => removeHeader(row.id)}
-                    title="Remove header"
-                  />
-                </Space.Compact>
-              ))}
-              <Button icon={<PlusOutlined />} onClick={addHeader} size="small">
-                Add header
-              </Button>
-            </Space>
-          </FormField>
+          {/* Raw mode: endpoints + headers. Slack mode hides these — headers
+              don't apply to the Slack connector. */}
+          {form.format === 'raw' && (
+            <>
+              <FormField
+                label="Endpoints"
+                yamlPath="advanced.event_delivery.webhook_urls"
+                helpText="HTTP(S) URLs that receive a deltaglider.event.v1 JSON payload. An event is marked delivered only after every endpoint returns 2xx."
+              >
+                <Space direction="vertical" style={{ width: '100%' }}>
+                  {form.urlRows.length === 0 && (
+                    <Text type="secondary" style={{ fontSize: 12 }}>
+                      No endpoints. Add one to start delivering.
+                    </Text>
+                  )}
+                  {form.urlRows.map((row) => (
+                    <Space.Compact key={row.id} style={{ width: '100%' }}>
+                      <Input
+                        value={row.url}
+                        onChange={(e) => updateUrl(row.id, e.target.value)}
+                        placeholder="https://hooks.example.com/deltaglider"
+                        style={{ ...inputRadius, fontFamily: 'var(--font-mono)', fontSize: 13 }}
+                      />
+                      <Button
+                        icon={<DeleteOutlined />}
+                        onClick={() => removeUrl(row.id)}
+                        title="Remove endpoint"
+                      />
+                    </Space.Compact>
+                  ))}
+                  <Button icon={<PlusOutlined />} onClick={addUrl} size="small">
+                    Add endpoint
+                  </Button>
+                </Space>
+              </FormField>
+
+              <FormField
+                label="Headers"
+                yamlPath="advanced.event_delivery.webhook_headers"
+                helpText="Static headers sent with every request — e.g. an Authorization bearer token. Values are stored encrypted and shown masked; leave a masked value untouched to keep it."
+              >
+                <Space direction="vertical" style={{ width: '100%' }}>
+                  {form.headerRows.length === 0 && (
+                    <Text type="secondary" style={{ fontSize: 12 }}>
+                      No headers.
+                    </Text>
+                  )}
+                  {form.headerRows.map((row) => (
+                    <Space.Compact key={row.id} style={{ width: '100%' }}>
+                      <Input
+                        value={row.name}
+                        onChange={(e) => updateHeader(row.id, { name: e.target.value })}
+                        placeholder="Authorization"
+                        style={{ ...inputRadius, fontFamily: 'var(--font-mono)', fontSize: 13, width: '40%' }}
+                      />
+                      <Input
+                        value={row.masked ? '' : row.value}
+                        onChange={(e) => updateHeader(row.id, { value: e.target.value })}
+                        placeholder={row.masked ? '•••••••• (unchanged — type to replace)' : 'Bearer …'}
+                        style={{ ...inputRadius, fontFamily: 'var(--font-mono)', fontSize: 13 }}
+                      />
+                      <Button
+                        icon={<DeleteOutlined />}
+                        onClick={() => removeHeader(row.id)}
+                        title="Remove header"
+                      />
+                    </Space.Compact>
+                  ))}
+                  <Button icon={<PlusOutlined />} onClick={addHeader} size="small">
+                    Add header
+                  </Button>
+                </Space>
+              </FormField>
+            </>
+          )}
         </div>
       </div>
+
+      {/* Slack connector — edits the SAME form value (single source of truth). */}
+      {form.format === 'slack' && (
+        <SlackConnectorCard
+          form={form}
+          setField={setField}
+          nextId={nextId}
+          errors={liveErrors}
+          inputRadius={inputRadius}
+          updateUrl={updateUrl}
+          addUrl={addUrl}
+          removeUrl={removeUrl}
+        />
+      )}
 
       {/* Advanced tuning */}
       <div style={cardStyle}>

--- a/demo/s3-browser/ui/src/components/advancedPanels.tsx
+++ b/demo/s3-browser/ui/src/components/advancedPanels.tsx
@@ -23,16 +23,7 @@
  * ApplyDialog renders it as a blue banner.
  */
 import { useEffect, useState } from 'react';
-import {
-  Alert,
-  Button,
-  Input,
-  InputNumber,
-  Radio,
-  Space,
-  Switch,
-  Typography,
-} from 'antd';
+import { Alert, Input, InputNumber, Radio, Switch, Typography } from 'antd';
 import {
   CloudServerOutlined,
   DatabaseOutlined,
@@ -50,6 +41,7 @@ import { undefinedToNullSubset } from './advancedPayload';
 import SectionHeader from './SectionHeader';
 import FormField from './FormField';
 import ApplyDialog from './ApplyDialog';
+import StickyDirtyBar from './StickyDirtyBar';
 
 const { Text } = Typography;
 
@@ -184,6 +176,10 @@ function useAdvancedSubset<T extends Partial<AdvancedSectionBody>>(
 
 /** Render the dirty-state banner + ApplyDialog pair. Every Advanced
  *  sub-panel uses this same tail. */
+// Shared dirty UX for the Advanced sub-panels. Rendered at the TOP of each
+// PanelShell, so it owns the ApplyDialog (a modal — placement-independent) and
+// the floating StickyDirtyBar. The bar uses fixed-to-viewport positioning so it
+// pins to the bottom regardless of where in the flow this rail sits.
 function AdvancedApplyRail(props: {
   isDirty: boolean;
   applying: boolean;
@@ -196,30 +192,13 @@ function AdvancedApplyRail(props: {
 }) {
   return (
     <>
-      {props.isDirty && (
-        <Alert
-          type="warning"
-          showIcon
-          message="Unsaved changes to this section"
-          description="Review the diff in the Apply dialog before persisting."
-          action={
-            <Space>
-              <Button size="small" onClick={props.onDiscard} disabled={props.applying}>
-                Discard
-              </Button>
-              <Button
-                type="primary"
-                size="small"
-                onClick={props.onApply}
-                disabled={props.applying}
-                loading={props.applying}
-              >
-                Apply
-              </Button>
-            </Space>
-          }
-        />
-      )}
+      <StickyDirtyBar
+        visible={props.isDirty}
+        applying={props.applying}
+        onDiscard={props.onDiscard}
+        onApply={props.onApply}
+        floating
+      />
       <ApplyDialog
         open={props.applyOpen}
         section="advanced"

--- a/demo/s3-browser/ui/src/components/advancedPanels.tsx
+++ b/demo/s3-browser/ui/src/components/advancedPanels.tsx
@@ -267,7 +267,7 @@ export function ListenerTlsPanel({ onSessionExpired }: PanelProps) {
           title="HTTP listener"
           description="Where the proxy binds for incoming S3 traffic."
         />
-        <div style={{ marginTop: 16 }}>
+        <div>
           <FormField
             label={
               <>
@@ -296,7 +296,7 @@ export function ListenerTlsPanel({ onSessionExpired }: PanelProps) {
           title="TLS"
           description="Optional HTTPS for the listener. When disabled, the proxy speaks plain HTTP — put it behind a reverse proxy that terminates TLS for you."
         />
-        <div style={{ marginTop: 16 }}>
+        <div>
           <FormField label="Enable TLS" yamlPath="advanced.tls.enabled">
             <Switch
               checked={tlsEnabled}
@@ -376,7 +376,7 @@ export function CachesPanel({ onSessionExpired }: PanelProps) {
           title="Caches"
           description="In-memory caches the proxy uses to accelerate delta reconstruction and metadata lookups. Larger values trade memory for throughput."
         />
-        <div style={{ marginTop: 16 }}>
+        <div>
           <FormField
             label={
               <>
@@ -645,7 +645,7 @@ export function LoggingPanel({ onSessionExpired }: PanelProps) {
           title="Log level"
           description="tracing-subscriber EnvFilter string. Hot-reloadable: changes take effect on the next request after Apply."
         />
-        <div style={{ marginTop: 16 }}>
+        <div>
           <Radio.Group
             value={radioValue}
             onChange={(e) => {

--- a/demo/s3-browser/ui/src/components/advancedPanels.tsx
+++ b/demo/s3-browser/ui/src/components/advancedPanels.tsx
@@ -40,8 +40,8 @@ import {
   ControlOutlined,
   SyncOutlined,
 } from '@ant-design/icons';
-import type { AdminConfig, SectionApplyResponse } from '../adminApi';
-import { getAdminConfig } from '../adminApi';
+import type { SectionApplyResponse } from '../adminApi';
+import { useAdminConfig } from '../queries/config';
 import { useColors } from '../ThemeContext';
 import { useCardStyles } from './shared-styles';
 import { useSectionEditor } from '../useSectionEditor';
@@ -491,29 +491,18 @@ export function CachesPanel({ onSessionExpired }: PanelProps) {
 export function LimitsPanel({ onSessionExpired }: PanelProps) {
   const { cardStyle, inputRadius } = useCardStyles();
   const { ACCENT_AMBER, TEXT_SECONDARY, BG_ELEVATED, BORDER, TEXT_MUTED } = useColors();
-  const [config, setConfig] = useState<AdminConfig | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  // Read-only env-var view of the running config (cached react-query read).
+  const { data: config, error: queryError, isError } = useAdminConfig();
 
+  // getAdminConfig resolves to `null` on a 401; treat as session-expiry.
   useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      try {
-        const cfg = await getAdminConfig();
-        if (cancelled) return;
-        if (!cfg) {
-          onSessionExpired?.();
-          return;
-        }
-        setConfig(cfg);
-      } catch (e) {
-        if (cancelled) return;
-        setError(e instanceof Error ? e.message : 'Failed to load');
-      }
-    })();
-    return () => { cancelled = true; };
-  }, [onSessionExpired]);
+    if (config === null) onSessionExpired?.();
+  }, [config, onSessionExpired]);
 
-  if (error) return <Alert type="error" showIcon message="Failed to load" description={error} />;
+  if (isError) {
+    const msg = queryError instanceof Error ? queryError.message : 'Failed to load';
+    return <Alert type="error" showIcon message="Failed to load" description={msg} />;
+  }
   if (!config) return <PanelShell><Text type="secondary">Loading...</Text></PanelShell>;
 
   const readOnlyField = (

--- a/demo/s3-browser/ui/src/components/sectionOverviews.tsx
+++ b/demo/s3-browser/ui/src/components/sectionOverviews.tsx
@@ -22,8 +22,9 @@
  */
 import { useEffect, useState } from 'react';
 import { TeamOutlined, CloudServerOutlined, SettingOutlined } from '@ant-design/icons';
-import type { AdminConfig, ExternalProviderInfo } from '../adminApi';
-import { getAdminConfig, whoami, getUsers, getGroups } from '../adminApi';
+import type { ExternalProviderInfo } from '../adminApi';
+import { whoami, getUsers, getGroups } from '../adminApi';
+import { useAdminConfig } from '../queries/config';
 import SectionOverview from './SectionOverview';
 import type { OverviewCard, OverviewStat } from './SectionOverview';
 import { childrenForPath } from './adminNavigation';
@@ -54,29 +55,24 @@ interface OverviewProps {
   onSessionExpired?: () => void;
 }
 
-function useAdminConfig(onSessionExpired?: () => void) {
-  const [config, setConfig] = useState<AdminConfig | null>(null);
-  const [error, setError] = useState<string | null>(null);
+/**
+ * Overview-config reader: thin wrapper over the shared `useAdminConfig`
+ * react-query hook that preserves the prior `{ config, error }` contract
+ * (string error, session-expired callback on a null/401 response).
+ */
+function useOverviewConfig(onSessionExpired?: () => void) {
+  const { data, error: queryError, isError } = useAdminConfig();
+  // getAdminConfig resolves to `null` on a non-OK (e.g. 401) response;
+  // treat that as a session-expiry signal like the old effect did.
   useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      try {
-        const cfg = await getAdminConfig();
-        if (cancelled) return;
-        if (!cfg) {
-          onSessionExpired?.();
-          return;
-        }
-        setConfig(cfg);
-      } catch (e) {
-        if (cancelled) return;
-        setError(e instanceof Error ? e.message : 'Failed to load config');
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [onSessionExpired]);
+    if (data === null) onSessionExpired?.();
+  }, [data, onSessionExpired]);
+  const config = data ?? null;
+  const error = isError
+    ? queryError instanceof Error
+      ? queryError.message
+      : 'Failed to load config'
+    : null;
   return { config, error };
 }
 
@@ -85,7 +81,7 @@ function useAdminConfig(onSessionExpired?: () => void) {
 // ═══════════════════════════════════════════════════
 
 export function AccessOverview({ onNavigateAdmin, onSessionExpired }: OverviewProps) {
-  const { config, error } = useAdminConfig(onSessionExpired);
+  const { config, error } = useOverviewConfig(onSessionExpired);
   // Users / groups / providers counts live outside AdminConfig —
   // fetch them in parallel. We tolerate errors here: if the IAM DB
   // is empty or the IAM mode is declarative and the lister returns
@@ -232,7 +228,7 @@ export function AccessOverview({ onNavigateAdmin, onSessionExpired }: OverviewPr
 // ═══════════════════════════════════════════════════
 
 export function StorageOverview({ onNavigateAdmin, onSessionExpired }: OverviewProps) {
-  const { config, error } = useAdminConfig(onSessionExpired);
+  const { config, error } = useOverviewConfig(onSessionExpired);
   if (error) {
     return <Alert type="error" showIcon message="Failed to load" description={error} />;
   }
@@ -335,7 +331,7 @@ export function StorageOverview({ onNavigateAdmin, onSessionExpired }: OverviewP
 // ═══════════════════════════════════════════════════
 
 export function AdvancedOverview({ onNavigateAdmin, onSessionExpired }: OverviewProps) {
-  const { config, error } = useAdminConfig(onSessionExpired);
+  const { config, error } = useOverviewConfig(onSessionExpired);
   if (error) {
     return <Alert type="error" showIcon message="Failed to load" description={error} />;
   }

--- a/demo/s3-browser/ui/src/components/webhookDeliveryPayload.ts
+++ b/demo/s3-browser/ui/src/components/webhookDeliveryPayload.ts
@@ -48,6 +48,23 @@ export const SLACK_NOTIFY_KINDS = [
 
 type EventDeliveryFormat = 'raw' | 'slack';
 
+/** One bucket/prefix → channel routing rule, wire shape. Mirrors `SlackRoute`
+ *  in src/config_sections.rs. `channel` is required; `bucket` absent/empty =
+ *  any bucket; `prefix_globs` empty = any key. */
+interface SlackRouteWire {
+  name?: string | null;
+  bucket?: string | null;
+  prefix_globs?: string[];
+  channel?: string | null;
+}
+
+interface SlackRouteNorm {
+  name: string;
+  bucket: string;
+  prefixGlobs: string[];
+  channel: string;
+}
+
 interface EventDeliveryConfig {
   enabled: boolean;
   webhook_urls: string[];
@@ -72,6 +89,7 @@ interface EventDeliveryConfig {
   slack_include_globs: string[];
   slack_exclude_globs: string[];
   slack_notify_kinds: string[];
+  slack_routes: SlackRouteNorm[];
 }
 
 /** Defaults mirror `EventDeliveryConfig::default` in src/config_sections.rs. */
@@ -97,6 +115,7 @@ const DEFAULT_EVENT_DELIVERY: EventDeliveryConfig = {
   slack_include_globs: [],
   slack_exclude_globs: [],
   slack_notify_kinds: ['ObjectCreated'],
+  slack_routes: [],
 };
 
 /** The wire shape of `event_delivery` as the server GET returns it. */
@@ -123,6 +142,7 @@ export interface EventDeliveryWire {
   slack_include_globs?: string[];
   slack_exclude_globs?: string[];
   slack_notify_kinds?: string[];
+  slack_routes?: SlackRouteWire[];
 }
 
 export interface AdvancedSectionWebhookBody {
@@ -173,6 +193,12 @@ function normalizeEventDelivery(
       ed.slack_notify_kinds && ed.slack_notify_kinds.length > 0
         ? [...ed.slack_notify_kinds]
         : [...d.slack_notify_kinds],
+    slack_routes: (ed.slack_routes ?? []).map((r) => ({
+      name: r.name ?? '',
+      bucket: r.bucket ?? '',
+      prefixGlobs: [...(r.prefix_globs ?? [])],
+      channel: r.channel ?? '',
+    })),
   };
 }
 
@@ -192,6 +218,18 @@ interface ValidationResult {
   errors: string[];
   /** Wire body for the section PUT, only present when ok. */
   body?: AdvancedSectionWebhookBody;
+}
+
+/** A route is "in progress" (safely droppable) only when EVERY field is blank.
+ *  Any non-empty field makes it meaningful — so a half-filled route still gets
+ *  validated (e.g. a bucket set but no channel → "Route N needs a channel"). */
+function routeHasContent(r: SlackRouteNorm): boolean {
+  return (
+    r.name.trim().length > 0 ||
+    r.bucket.trim().length > 0 ||
+    r.channel.trim().length > 0 ||
+    r.prefixGlobs.some((g) => g.trim().length > 0)
+  );
 }
 
 /**
@@ -224,9 +262,13 @@ function buildEventDeliveryPayload(
       errors.push('Delivery is enabled but no endpoint is set — add at least one webhook URL or turn delivery off.');
     }
   } else {
+    // Channel-routing rows that actually carry content (blank rows are dropped).
+    const meaningfulRoutes = local.slack_routes.filter((r) => routeHasContent(r));
     if (slackBotMode) {
-      // Bot-token mode posts via the Web API to a specific channel.
-      if (local.slack_channel.trim().length === 0) {
+      // Bot-token mode posts via the Web API. A destination is needed: either
+      // the single fallback channel OR at least one route. (Mirrors the backend:
+      // it warns only when slack_routes is empty AND slack_channel is unset.)
+      if (local.slack_channel.trim().length === 0 && meaningfulRoutes.length === 0) {
         errors.push('Slack bot-token mode needs a channel.');
       }
     } else if (local.enabled && urls.length === 0) {
@@ -242,6 +284,19 @@ function buildEventDeliveryPayload(
     if (local.slack_notify_kinds.length === 0) {
       errors.push('Pick at least one event kind to post to Slack.');
     }
+    // Channel routing (bot-token mode only). Blank rows are dropped; what's left
+    // must each carry a channel. Routes outside bot-token mode are a no-op on the
+    // backend (Incoming Webhook URLs are 1:1 with a channel) — surface that.
+    if (meaningfulRoutes.length > 0 && !slackBotMode) {
+      errors.push(
+        'Channel routing needs a bot token — Incoming Webhook URLs are each bound to one channel by Slack. Switch to bot-token mode or remove the routes.'
+      );
+    }
+    meaningfulRoutes.forEach((r, i) => {
+      if (r.channel.trim().length === 0) {
+        errors.push(`Route ${i + 1} needs a channel.`);
+      }
+    });
   }
 
   // Header validation + secret-sentinel guard.
@@ -334,6 +389,20 @@ function buildEventDeliveryPayload(
       slack_include_globs: local.slack_include_globs.map((g) => g.trim()).filter((g) => g.length > 0),
       slack_exclude_globs: local.slack_exclude_globs.map((g) => g.trim()).filter((g) => g.length > 0),
       slack_notify_kinds: [...local.slack_notify_kinds],
+      // Only routes with a real channel reach the wire; blank/in-progress rows
+      // are dropped. name/bucket are omitted when empty (= any bucket; no label).
+      slack_routes: local.slack_routes
+        .filter((r) => r.channel.trim().length > 0)
+        .map((r) => {
+          const route: SlackRouteWire = { channel: r.channel.trim() };
+          const name = r.name.trim();
+          if (name) route.name = name;
+          const bucket = r.bucket.trim();
+          if (bucket) route.bucket = bucket;
+          const globs = r.prefixGlobs.map((g) => g.trim()).filter((g) => g.length > 0);
+          if (globs.length > 0) route.prefix_globs = globs;
+          return route;
+        }),
     },
   };
 
@@ -361,6 +430,17 @@ export interface WebhookUrlRow {
 export interface SlackGlobRow {
   id: string;
   glob: string;
+}
+
+/** A stable-id channel-routing row: bucket/prefix → channel. Mirrors the wire
+ *  `SlackRoute`. Carries a stable `id` (React key — NEVER array index) and a
+ *  nested list of stable-id glob rows for the prefix matcher. */
+export interface SlackRouteRow {
+  id: string;
+  name: string;
+  bucket: string;
+  prefixGlobs: SlackGlobRow[];
+  channel: string;
 }
 
 export interface WebhookHeaderRow {
@@ -415,6 +495,9 @@ export interface WebhookFormState {
   slackIncludeRows: SlackGlobRow[];
   slackExcludeRows: SlackGlobRow[];
   slackNotifyKinds: string[];
+  /** Per-bucket / per-prefix → channel routes (bot-token mode only). Empty =
+   *  the single-channel behavior (`slackChannel` is the only destination). */
+  slackRoutes: SlackRouteRow[];
 }
 
 // Deterministic id generator INJECTED by the caller so this module stays pure
@@ -459,6 +542,13 @@ export function formFromWire(
     slackIncludeRows: cfg.slack_include_globs.map((glob) => ({ id: nextId(), glob })),
     slackExcludeRows: cfg.slack_exclude_globs.map((glob) => ({ id: nextId(), glob })),
     slackNotifyKinds: [...cfg.slack_notify_kinds],
+    slackRoutes: cfg.slack_routes.map((r) => ({
+      id: nextId(),
+      name: r.name,
+      bucket: r.bucket,
+      prefixGlobs: r.prefixGlobs.map((glob) => ({ id: nextId(), glob })),
+      channel: r.channel,
+    })),
   };
 }
 
@@ -508,6 +598,12 @@ export function buildPayloadFromForm(form: WebhookFormState): ValidationResult {
     slack_include_globs: form.slackIncludeRows.map((r) => r.glob),
     slack_exclude_globs: form.slackExcludeRows.map((r) => r.glob),
     slack_notify_kinds: [...form.slackNotifyKinds],
+    slack_routes: form.slackRoutes.map((r) => ({
+      name: r.name,
+      bucket: r.bucket,
+      prefixGlobs: r.prefixGlobs.map((g) => g.glob),
+      channel: r.channel,
+    })),
   };
   for (const h of form.headerRows) {
     const name = h.name.trim();
@@ -530,4 +626,107 @@ export function buildPayloadFromForm(form: WebhookFormState): ValidationResult {
     return { ok: false, errors: [...errors, ...res.errors] };
   }
   return res;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Preview-only channel resolution (mirrors src/slack_format.rs::resolve_channels).
+//
+// Best-effort, client-side: a glob match close to `globset` semantics (`**`
+// crosses `/`, `*` stays within a path segment). NOT an exact globset port —
+// it's a live-preview aid, so bucket-match + simple prefix are what must be
+// right. Kept pure so the regression test can exercise it without a server.
+// ─────────────────────────────────────────────────────────────────────────
+
+/** Compile one glob to a RegExp. `**` → `.*` (crosses `/`); `*` → `[^/]*`
+ *  (within a segment); `?` → `[^/]`. All other regex metachars are escaped. */
+function globToRegExp(glob: string): RegExp {
+  let re = '';
+  for (let i = 0; i < glob.length; i++) {
+    const ch = glob[i];
+    if (ch === '*') {
+      if (glob[i + 1] === '*') {
+        re += '.*';
+        i++; // consume the second star
+      } else {
+        re += '[^/]*';
+      }
+    } else if (ch === '?') {
+      re += '[^/]';
+    } else if ('.+^${}()|[]\\'.includes(ch)) {
+      re += '\\' + ch;
+    } else {
+      re += ch;
+    }
+  }
+  return new RegExp(`^${re}$`);
+}
+
+function globMatchesAny(globs: string[], key: string): boolean {
+  for (const g of globs) {
+    const trimmed = g.trim();
+    if (!trimmed) continue;
+    try {
+      if (globToRegExp(trimmed).test(key)) return true;
+    } catch {
+      // An un-compilable glob never matches (the backend warns on it too).
+    }
+  }
+  return false;
+}
+
+/** A resolved-channel preview row: which route matched, and its channel. */
+interface ResolvedRoute {
+  /** Route label (name) if set, else a synthesized description. */
+  label: string;
+  channel: string;
+}
+
+interface ResolveResult {
+  /** Channels the sample event would post to, in route order, deduped. */
+  matches: ResolvedRoute[];
+  /** True when no route matched and we fell back to the single channel. */
+  fellBackToChannel: boolean;
+  /** The fallback channel used (only meaningful when `fellBackToChannel`). */
+  fallbackChannel: string;
+}
+
+/**
+ * Resolve which channel(s) a SAMPLE `bucket`/`key` event posts to, mirroring
+ * the Rust `resolve_channels`: when `routes` is non-empty, fan out to EVERY
+ * matching route (bucket absent/empty = any; prefix_globs empty = any key),
+ * deduped by channel; otherwise fall back to the single `slackChannel`.
+ */
+export function resolveSlackChannelsPreview(
+  routes: SlackRouteRow[],
+  fallbackChannel: string,
+  sampleBucket: string,
+  sampleKey: string
+): ResolveResult {
+  const meaningful = routes.filter((r) => r.channel.trim().length > 0);
+  if (meaningful.length === 0) {
+    const fb = fallbackChannel.trim();
+    return { matches: [], fellBackToChannel: fb.length > 0, fallbackChannel: fb };
+  }
+
+  const out: ResolvedRoute[] = [];
+  const seen = new Set<string>();
+  for (const route of meaningful) {
+    const bucket = route.bucket.trim();
+    if (bucket && bucket !== sampleBucket.trim()) continue;
+    const globs = route.prefixGlobs.map((g) => g.glob).filter((g) => g.trim().length > 0);
+    if (globs.length > 0 && !globMatchesAny(globs, sampleKey)) continue;
+    const channel = route.channel.trim();
+    if (!channel || seen.has(channel)) continue;
+    seen.add(channel);
+    out.push({
+      label: route.name.trim() || (bucket ? `bucket ${bucket}` : 'any bucket'),
+      channel,
+    });
+  }
+
+  if (out.length === 0) {
+    const fb = fallbackChannel.trim();
+    return { matches: [], fellBackToChannel: fb.length > 0, fallbackChannel: fb };
+  }
+  return { matches: out, fellBackToChannel: false, fallbackChannel: '' };
 }

--- a/demo/s3-browser/ui/src/components/webhookDeliveryPayload.ts
+++ b/demo/s3-browser/ui/src/components/webhookDeliveryPayload.ts
@@ -23,9 +23,30 @@
  *    list bound to `webhook_urls`; on load we fold any legacy single
  *    `webhook_url` into the list, and on save we always write `webhook_urls`
  *    and clear `webhook_url` (→ explicit `null`) so the two never drift.
+ *
+ * 4. **Slack format + bot-token secret.** `format` selects the payload shape:
+ *    `raw` (existing JSON envelope) or `slack` (Block Kit message). In `slack`
+ *    mode the message lands either via an Incoming Webhook URL (no token) or the
+ *    Slack Web API (`slack_bot_token` set, requires `slack_channel`). The bot
+ *    token is a SECRET with the SAME mask round-trip as header values: masked to
+ *    the sentinel on GET, passed through untouched (= "unchanged", server
+ *    restores), overwritten when retyped, cleared to `null` when emptied.
  */
 
 const WEBHOOK_REDACTED_SENTINEL = '__redacted__';
+
+/** Event kinds the backend recognises for `slack_notify_kinds`. Mirrors
+ *  `default_slack_notify_kinds` + the valid set in src/config_sections.rs. */
+export const SLACK_NOTIFY_KINDS = [
+  'ObjectCreated',
+  'ObjectDeleted',
+  'ObjectCopied',
+  'ReplicationObjectCopied',
+  'LifecycleTransitioned',
+  'LifecycleExpired',
+] as const;
+
+type EventDeliveryFormat = 'raw' | 'slack';
 
 interface EventDeliveryConfig {
   enabled: boolean;
@@ -41,6 +62,16 @@ interface EventDeliveryConfig {
   delivered_retention: string;
   delivered_max_rows: number;
   prune_batch: number;
+  // Slack
+  format: EventDeliveryFormat;
+  /** Equals the sentinel while an untouched bot token is masked; '' = unset. */
+  slack_bot_token: string;
+  slack_channel: string;
+  slack_username: string;
+  slack_icon_emoji: string;
+  slack_include_globs: string[];
+  slack_exclude_globs: string[];
+  slack_notify_kinds: string[];
 }
 
 /** Defaults mirror `EventDeliveryConfig::default` in src/config_sections.rs. */
@@ -58,6 +89,14 @@ const DEFAULT_EVENT_DELIVERY: EventDeliveryConfig = {
   delivered_retention: '24h',
   delivered_max_rows: 10000,
   prune_batch: 100,
+  format: 'raw',
+  slack_bot_token: '',
+  slack_channel: '',
+  slack_username: '',
+  slack_icon_emoji: '',
+  slack_include_globs: [],
+  slack_exclude_globs: [],
+  slack_notify_kinds: ['ObjectCreated'],
 };
 
 /** The wire shape of `event_delivery` as the server GET returns it. */
@@ -76,6 +115,14 @@ export interface EventDeliveryWire {
   delivered_retention?: string;
   delivered_max_rows?: number;
   prune_batch?: number;
+  format?: EventDeliveryFormat;
+  slack_bot_token?: string | null;
+  slack_channel?: string | null;
+  slack_username?: string | null;
+  slack_icon_emoji?: string | null;
+  slack_include_globs?: string[];
+  slack_exclude_globs?: string[];
+  slack_notify_kinds?: string[];
 }
 
 export interface AdvancedSectionWebhookBody {
@@ -114,6 +161,18 @@ function normalizeEventDelivery(
     delivered_retention: ed.delivered_retention ?? d.delivered_retention,
     delivered_max_rows: ed.delivered_max_rows ?? d.delivered_max_rows,
     prune_batch: ed.prune_batch ?? d.prune_batch,
+    format: ed.format === 'slack' ? 'slack' : 'raw',
+    // A null/absent token → unset (''); the sentinel survives as "masked".
+    slack_bot_token: ed.slack_bot_token ?? '',
+    slack_channel: ed.slack_channel ?? '',
+    slack_username: ed.slack_username ?? '',
+    slack_icon_emoji: ed.slack_icon_emoji ?? '',
+    slack_include_globs: [...(ed.slack_include_globs ?? [])],
+    slack_exclude_globs: [...(ed.slack_exclude_globs ?? [])],
+    slack_notify_kinds:
+      ed.slack_notify_kinds && ed.slack_notify_kinds.length > 0
+        ? [...ed.slack_notify_kinds]
+        : [...d.slack_notify_kinds],
   };
 }
 
@@ -152,9 +211,37 @@ function buildEventDeliveryPayload(
   for (const u of urls) {
     if (!URL_RE.test(u)) errors.push(`Endpoint "${u}" is not a valid http(s) URL.`);
   }
-  // Usability invariant: enabling delivery with no endpoint is a no-op trap.
-  if (local.enabled && urls.length === 0) {
-    errors.push('Delivery is enabled but no endpoint is set — add at least one webhook URL or turn delivery off.');
+
+  const isSlack = local.format === 'slack';
+  const slackToken = local.slack_bot_token.trim();
+  // Bot-token mode = a real token typed OR an untouched (masked) token carried
+  // over from load. Either way the backend will use the Web API → needs channel.
+  const slackBotMode = isSlack && slackToken.length > 0;
+
+  if (!isSlack) {
+    // Usability invariant: enabling delivery with no endpoint is a no-op trap.
+    if (local.enabled && urls.length === 0) {
+      errors.push('Delivery is enabled but no endpoint is set — add at least one webhook URL or turn delivery off.');
+    }
+  } else {
+    if (slackBotMode) {
+      // Bot-token mode posts via the Web API to a specific channel.
+      if (local.slack_channel.trim().length === 0) {
+        errors.push('Slack bot-token mode needs a channel.');
+      }
+    } else if (local.enabled && urls.length === 0) {
+      // Webhook mode: the hooks.slack.com URL is the only delivery path.
+      errors.push('Delivery is enabled but no Slack Incoming Webhook URL is set — add the hooks.slack.com URL or turn delivery off.');
+    }
+    // Basic glob sanity (backend warns on the rest — don't over-validate).
+    for (const g of [...local.slack_include_globs, ...local.slack_exclude_globs]) {
+      if (g.trim().length === 0) {
+        errors.push('A Slack prefix filter is empty — remove the blank row or fill it in.');
+      }
+    }
+    if (local.slack_notify_kinds.length === 0) {
+      errors.push('Pick at least one event kind to post to Slack.');
+    }
   }
 
   // Header validation + secret-sentinel guard.
@@ -207,6 +294,20 @@ function buildEventDeliveryPayload(
     }
   }
 
+  // Bot token: sentinel = "unchanged" (pass through, server restores the real
+  // token); a real typed value overwrites; empty/whitespace clears to null.
+  const tokenTrim = local.slack_bot_token.trim();
+  const slackBotToken: string | null =
+    local.slack_bot_token === WEBHOOK_REDACTED_SENTINEL
+      ? WEBHOOK_REDACTED_SENTINEL
+      : tokenTrim.length > 0
+        ? tokenTrim
+        : null;
+  const strOrNull = (v: string): string | null => {
+    const t = v.trim();
+    return t.length > 0 ? t : null;
+  };
+
   const body: AdvancedSectionWebhookBody = {
     event_delivery: {
       enabled: local.enabled,
@@ -224,6 +325,15 @@ function buildEventDeliveryPayload(
       delivered_retention: local.delivered_retention.trim(),
       delivered_max_rows: local.delivered_max_rows,
       prune_batch: local.prune_batch,
+      // Slack — always emitted so the merge-patch reflects the editor's intent.
+      format: local.format,
+      slack_bot_token: slackBotToken,
+      slack_channel: strOrNull(local.slack_channel),
+      slack_username: strOrNull(local.slack_username),
+      slack_icon_emoji: strOrNull(local.slack_icon_emoji),
+      slack_include_globs: local.slack_include_globs.map((g) => g.trim()).filter((g) => g.length > 0),
+      slack_exclude_globs: local.slack_exclude_globs.map((g) => g.trim()).filter((g) => g.length > 0),
+      slack_notify_kinds: [...local.slack_notify_kinds],
     },
   };
 
@@ -243,6 +353,14 @@ function buildEventDeliveryPayload(
 export interface WebhookUrlRow {
   id: string;
   url: string;
+}
+
+/** A stable-id glob row for the Slack include/exclude prefix filters. Same
+ *  id-keyed pattern as {@link WebhookUrlRow} so React keys stay stable across
+ *  edits (never array index — see the admin-editor bug class). */
+export interface SlackGlobRow {
+  id: string;
+  glob: string;
 }
 
 export interface WebhookHeaderRow {
@@ -276,6 +394,27 @@ export interface WebhookFormState {
   delivered_retention: string;
   delivered_max_rows: number;
   prune_batch: number;
+  // ── Slack ──
+  /** `raw` (existing JSON envelope) or `slack` (Block Kit message). */
+  format: EventDeliveryFormat;
+  /**
+   * UI-only: which Slack sub-mode the operator is editing (Incoming Webhook vs
+   * Bot token). The BACKEND mode is derived from whether a token is present, so
+   * this is never sent on the wire (`buildPayloadFromForm` ignores it). It lives
+   * on the editor value — the single source of truth — so the toggle stays sticky
+   * even while the bot-token field is momentarily empty. Initialised from token
+   * presence in `formFromWire`. */
+  slackPreferBotMode: boolean;
+  /** Bot token. Equals the sentinel while an untouched secret is masked. */
+  slackBotToken: string;
+  /** True while `slackBotToken` is still the server sentinel (untouched). */
+  slackBotTokenMasked: boolean;
+  slackChannel: string;
+  slackUsername: string;
+  slackIconEmoji: string;
+  slackIncludeRows: SlackGlobRow[];
+  slackExcludeRows: SlackGlobRow[];
+  slackNotifyKinds: string[];
 }
 
 // Deterministic id generator INJECTED by the caller so this module stays pure
@@ -309,6 +448,17 @@ export function formFromWire(
     delivered_retention: cfg.delivered_retention,
     delivered_max_rows: cfg.delivered_max_rows,
     prune_batch: cfg.prune_batch,
+    format: cfg.format,
+    // Bot mode iff a token (real or masked) is present at load.
+    slackPreferBotMode: cfg.slack_bot_token.trim().length > 0,
+    slackBotToken: cfg.slack_bot_token,
+    slackBotTokenMasked: cfg.slack_bot_token === WEBHOOK_REDACTED_SENTINEL,
+    slackChannel: cfg.slack_channel,
+    slackUsername: cfg.slack_username,
+    slackIconEmoji: cfg.slack_icon_emoji,
+    slackIncludeRows: cfg.slack_include_globs.map((glob) => ({ id: nextId(), glob })),
+    slackExcludeRows: cfg.slack_exclude_globs.map((glob) => ({ id: nextId(), glob })),
+    slackNotifyKinds: [...cfg.slack_notify_kinds],
   };
 }
 
@@ -330,6 +480,12 @@ export function buildPayloadFromForm(form: WebhookFormState): ValidationResult {
     }
   }
 
+  // Bot token: a still-masked field carries the sentinel through so the server
+  // restores the real token; a retyped (unmasked) field carries the literal.
+  const slackBotToken = form.slackBotTokenMasked
+    ? WEBHOOK_REDACTED_SENTINEL
+    : form.slackBotToken;
+
   const local: EventDeliveryConfig = {
     enabled: form.enabled,
     webhook_urls: form.urlRows.map((r) => r.url),
@@ -344,6 +500,14 @@ export function buildPayloadFromForm(form: WebhookFormState): ValidationResult {
     delivered_retention: form.delivered_retention,
     delivered_max_rows: form.delivered_max_rows,
     prune_batch: form.prune_batch,
+    format: form.format,
+    slack_bot_token: slackBotToken,
+    slack_channel: form.slackChannel,
+    slack_username: form.slackUsername,
+    slack_icon_emoji: form.slackIconEmoji,
+    slack_include_globs: form.slackIncludeRows.map((r) => r.glob),
+    slack_exclude_globs: form.slackExcludeRows.map((r) => r.glob),
+    slack_notify_kinds: [...form.slackNotifyKinds],
   };
   for (const h of form.headerRows) {
     const name = h.name.trim();

--- a/demo/s3-browser/ui/src/components/webhookDeliveryPayload.ts
+++ b/demo/s3-browser/ui/src/components/webhookDeliveryPayload.ts
@@ -724,9 +724,8 @@ export function resolveSlackChannelsPreview(
     });
   }
 
-  if (out.length === 0) {
-    const fb = fallbackChannel.trim();
-    return { matches: [], fellBackToChannel: fb.length > 0, fallbackChannel: fb };
-  }
+  // Routes EXIST but none matched → the backend posts NOWHERE (resolve_channels
+  // only falls back to slack_channel when there are zero routes). Do NOT show
+  // the fallback here, or the preview would claim delivery the backend won't do.
   return { matches: out, fellBackToChannel: false, fallbackChannel: '' };
 }

--- a/demo/s3-browser/ui/src/theme.css
+++ b/demo/s3-browser/ui/src/theme.css
@@ -917,6 +917,19 @@ body {
   }
 }
 
+/* ───── FormField: YAML-path code chip reveals on hover ───── */
+.dg-field .dg-yaml-path {
+  opacity: 0;
+  transition: opacity 120ms ease;
+  pointer-events: none;
+}
+.dg-field:hover .dg-yaml-path,
+.dg-field:focus-within .dg-yaml-path,
+.dg-field .dg-yaml-path:focus-visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
 /* ───── Accessibility: respect reduced motion ───── */
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after {

--- a/demo/s3-browser/ui/src/useSectionEditor.ts
+++ b/demo/s3-browser/ui/src/useSectionEditor.ts
@@ -35,8 +35,10 @@
  */
 import { useCallback, useEffect, useState } from 'react';
 import { message } from 'antd';
+import { useQueryClient } from '@tanstack/react-query';
 import type { SectionApplyResponse, SectionName } from './adminApi';
 import { getSection, putSection, validateSection } from './adminApi';
+import { qk } from './queries/keys';
 import { useApplyHandler, useDirtySection } from './useDirtySection';
 
 interface UseSectionEditorOptions<Wire, Local = Wire> {
@@ -127,6 +129,7 @@ export function useSectionEditor<Wire, Local = Wire>(
 
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const queryClient = useQueryClient();
   const { value, isDirty, setValue, discard, markApplied, resetWith } =
     useDirtySection<Local>(dirtyKey, initial);
 
@@ -208,6 +211,11 @@ export function useSectionEditor<Wire, Local = Wire>(
       markApplied();
       setApplyOpen(false);
       setPendingBody(null);
+      // Other panels read the full config via the cached `qk.config()`
+      // query (AdmissionPanel's synthesised-blocks preview, Authentication/
+      // Groups banners, the section overviews, etc.). A section PUT changed
+      // server truth, so invalidate that cache to refetch.
+      void queryClient.invalidateQueries({ queryKey: qk.config() });
       void refresh();
     } catch (e) {
       // Apply failed (network/server error). Close the dialog but do NOT
@@ -221,7 +229,7 @@ export function useSectionEditor<Wire, Local = Wire>(
     } finally {
       setApplying(false);
     }
-  }, [section, pendingBody, markApplied, refresh]);
+  }, [section, pendingBody, markApplied, refresh, queryClient]);
 
   // ⌘S wiring: when dirty, ⌘S opens the validate → ApplyDialog sequence.
   // Registered under dirtyKey so ⌘S reaches the active panel, not all

--- a/docs/dev/contributing.md
+++ b/docs/dev/contributing.md
@@ -121,6 +121,58 @@ docs/                    # Documentation
 - **StorageBackend**: A trait abstracting where bytes live — local filesystem or upstream S3. Adding a new backend means implementing this trait.
 - **File router**: Decides whether a file is delta-eligible based on its extension (`.zip`, `.jar`, `.tar`, etc.) or should be stored as passthrough (`.jpg`, `.mp4`, etc.).
 
+## Admin-UI patterns (frontend)
+
+The admin GUI (`demo/s3-browser/ui`) has converged on a small set of canonical
+patterns. New panels and edits should follow these rather than re-inventing —
+divergence here has historically produced a recurring "admin-editor bug class"
+(stale closures, array-index keys, double sources of truth).
+
+**Two data families, two pipelines.**
+- **Config sections** (`admission` / `access` / `storage` / `advanced`) → the
+  **`useSectionEditor`** hook. It owns fetch → dirty-tracking → validate →
+  `ApplyDialog` → section-PUT → re-fetch, with `pick` (wire→form) / `toPayload`
+  (form→wire) hooks. The editor `value` IS the single source of truth — never
+  keep a parallel state mirror of it. Examples: Admission, Credentials, all
+  Advanced sub-panels, Webhook delivery, Replication, Lifecycle, Buckets.
+- **IAM DB resources** (users / groups / OAuth providers / mapping rules) →
+  **react-query** (`queries/`, keyed by `qk.*`) for reads + per-record mutations.
+  Read the cached admin config with `useAdminConfig()` — do NOT hand-roll
+  `useEffect(getAdminConfig().then(setState))`. After a config mutation,
+  invalidate `qk.config()` (the section editor already does this on apply).
+
+**Single source of truth for forms.** A form's React state should be the only
+copy of its editable data. For master-detail forms (User/Group/etc.), initialize
+state from the selected record with **lazy `useState(() => ...)` initializers +
+a `key` on the form** (`key={record.id}` for edit, `key="new"` for create) so a
+keyed remount resets state — never a `useEffect([record])` prop→state mirror.
+
+**Stable row ids, never array index.** Row-list editors (endpoints, headers,
+glob rows, routes, permissions, rules) key React lists by a stable id (a
+per-instance `nextId()` counter or the record's own id), and mutate rows by id
+(`rows.map(r => r.id === id ? {...} : r)`), never by index.
+
+**Pure helpers + Node regression tests.** Validation, payload-building, and
+normalization live in pure functions (e.g. `webhookDeliveryPayload.ts`'s
+`formFromWire` / `buildPayloadFromForm`), not inline in components, and get a
+`scripts/*-regression-test.mjs` Node test (registered in `package.json` + CI).
+Mirrors the Rust convention of pure decision-fns at seams (`classify_*`,
+`validate_*`, `resolve_*`) with colocated unit tests.
+
+**Secret round-trip.** Secret fields (webhook headers, Slack bot token, SigV4)
+are masked to the `REDACTED_SENTINEL` (`__redacted__`) on GET; the UI shows a
+"•••• (unchanged — type to replace)" placeholder and, on save, passes the
+sentinel through untouched so the backend preserves the real value — on BOTH the
+section-PUT and document export→apply paths. Removed map entries emit an explicit
+`null` (RFC 7396 delete).
+
+**Shared visual primitives** (reuse, don't re-style): `useCardStyles` /
+`SectionHeader` (cards), `FormField` (label + YAML-path breadcrumb + helpText +
+example chips — wrap every field; help should always be present), `StickyDirtyBar`
+(the slim floating unsaved-changes bar — use `floating` when it can't be the last
+child in the scroll flow), `ApplyDialog` (plan → diff → apply). Every editable
+field should have a `helpText` and a `placeholder`/example.
+
 ## Submitting Changes
 
 1. Fork the repo and create a branch from `main`

--- a/docs/plan/slack-connector-impl.md
+++ b/docs/plan/slack-connector-impl.md
@@ -1,0 +1,128 @@
+# Slack connector — implementation checklist
+
+Decisions (locked with user): **both** Slack modes (Incoming Webhook URL + `xoxb-`
+bot token); **`format` enum on `event_delivery`** (reuse outbox/retry/secret/GUI
+pipeline); **user-objects + prefix include/exclude** volume filter. NO OAuth — the
+Grafana-core / Sentry-legacy / GitLab-notifications model (paste-a-credential,
+works on private instances, outbound HTTPS only).
+
+## Backend (Rust)
+
+### B1. Config — extend `EventDeliveryConfig` (`src/config_sections.rs`)
+- `format: EventDeliveryFormat` (enum `Raw | Slack`, default `Raw`,
+  `#[serde(rename_all = "lowercase")]`, `JsonSchema`). When `Raw`, behavior is
+  unchanged (the existing `{schema,event}` JSON webhook).
+- Slack sub-config (flat fields, all optional, secret-bearing ones masked):
+  - `slack_bot_token: Option<String>` — `xoxb-…`. SECRET → redact like
+    webhook_headers (REDACTED_SENTINEL mask + preserve-on-untouched).
+  - `slack_channel: Option<String>` — channel id/name, required in token mode.
+  - `slack_username: Option<String>` / `slack_icon_emoji: Option<String>` —
+    cosmetic overrides (webhook mode).
+  - `slack_include_globs: Vec<String>` / `slack_exclude_globs: Vec<String>` —
+    key-prefix filters (reuse `build_globset`).
+  - `slack_notify_kinds: Vec<String>` — which EventKinds notify (default
+    `["ObjectCreated"]`; operator can add ObjectDeleted etc.).
+- Mode is implicit: `slack_bot_token` present → Web API (chat.postMessage);
+  else the existing `webhook_url`/`webhook_urls` (pointed at hooks.slack.com) →
+  Incoming Webhook. `is_active()` already requires an endpoint OR (new) a token.
+- Validation (`validate_event_delivery`): when `format=slack` + token mode,
+  require `slack_channel`; warn if both token and a non-slack webhook URL set;
+  validate globs compile; validate notify_kinds are known EventKinds.
+
+### B2. Redaction + preserve (mirror webhook_headers, already the pattern)
+- `redact_all_secrets` (`config.rs`): mask `slack_bot_token` →
+  `Some(REDACTED_SENTINEL)`.
+- `preserve_event_delivery_secrets` (`config/mod.rs`): if incoming
+  `slack_bot_token == sentinel` → restore old. Extend the existing fn; both
+  section-PUT and document-apply paths already call it. Add unit cases.
+
+### B3. Slack message formatter (`src/event_delivery/slack.rs`, pure + tested)
+- `fn slack_message(event: &EventOutboxRecord, cfg) -> serde_json::Value` →
+  Block Kit: a header (`📦 New file` / `🗑️ Deleted` per kind), a section with
+  `*bucket*/`key`` + size (humanized from payload.content_length) + storage_type
+  + a short etag, and a context line with the ISO timestamp. Plus a `text`
+  fallback (for notifications/screen readers — accessibility) so the message is
+  legible without Block Kit rendering.
+- `fn should_notify(event, include, exclude, kinds) -> bool` — pure: kind in
+  `notify_kinds` AND `is_user_object_key(key)` AND glob include/exclude pass.
+  Unit-tested truth table.
+- Emoji/title per `EventKind` (Created/Deleted/Copied/Lifecycle*).
+
+### B4. Delivery (`HttpWebhookDeliveryClient::deliver`, `event_delivery.rs`)
+- Early: if `should_notify` is false for a Slack-format config → return `Ok(())`
+  (consume the event silently; not every object notifies). Filtering happens at
+  delivery so the outbox/cursor accounting is unchanged.
+- Branch on `format`:
+  - **Raw**: existing path unchanged.
+  - **Slack + bot token**: POST `https://slack.com/api/chat.postMessage`,
+    `Authorization: Bearer <token>`, body `{channel, text, blocks}`.
+    **CRITICAL**: Slack Web API returns HTTP 200 even on failure — parse the JSON
+    body and treat `{"ok": false, "error": "..."}` as a delivery error (so retry
+    fires). A `{"ok": true}` is success.
+  - **Slack + webhook URL** (no token): POST each `hooks.slack.com` endpoint with
+    `{text, blocks, username?, icon_emoji?}`; 2xx = success (webhooks don't
+    return the ok-envelope).
+- Keep the per-endpoint retry/backoff/attempts machinery as-is.
+
+### B5. Tests
+- Unit (`event_delivery/slack.rs`): `slack_message` shape (header/section/text
+  fallback present; size humanized; bucket/key escaped), `should_notify` truth
+  table (kind filter, user-object filter, include/exclude globs).
+- Unit (config/mod): preserve restores masked `slack_bot_token`.
+- Integration (`event_delivery` test or a new one): a mock Slack endpoint
+  (existing `EventDeliveryClient` trait is mockable — there's a test client) —
+  assert chat.postMessage `{ok:false}` is treated as failure → retried; webhook
+  2xx is success; a filtered-out key produces no POST.
+
+## Frontend (GUI) — the "neat designed card"
+
+### F1. Format toggle in WebhookDeliveryPanel
+- A segmented control / radio at the top of the panel: **Raw webhook** |
+  **Slack**. Switching to Slack reveals the Slack card and hides the raw-header
+  editor (headers don't apply to Slack mode).
+
+### F2. SlackConnectorCard (new, the designed piece)
+A self-contained card with a guided, accessible layout:
+- **Mode sub-toggle**: "Incoming Webhook (simplest)" | "Bot token (multi-channel
+  + @mentions)". Each shows a 2-3 step mini-guide inline:
+  - Webhook: "1. Create a Slack app → 2. Enable Incoming Webhooks → 3. Paste the
+    `hooks.slack.com/…` URL." + the URL field (reuses the endpoint row editor).
+  - Bot token: "1. Create app → 2. Add `chat:write` + `chat:write.public` scopes
+    → 3. Install → 4. Paste the `xoxb-` token + channel." + masked token field
+    (reuses the secret-mask UX from the header editor) + channel field.
+  - A link to Slack's app-create page and (nice-to-have) a "copy app manifest"
+    button that gives a pre-filled minimal manifest (scopes preset) so setup is
+    one paste on Slack's side.
+- **Filters** (collapsible "What gets posted"): notify-on kinds (Created/Deleted
+  checkboxes), include/exclude prefix rows (reuse the endpoint row editor).
+- **Cosmetics** (collapsible): username, icon emoji.
+- **Live preview**: render a faux Slack message from the current settings (a
+  styled card mimicking Slack's layout: 📦 header + `bucket/key` + size) so the
+  operator sees what lands in the channel before saving. Pure client-side from
+  the form state.
+- Validation inline (token required-with-channel; at least one endpoint-or-token
+  when enabled; globs well-formed).
+- Heavy doc affordance: each field has the FormField yamlPath breadcrumb + help;
+  a top-of-card callout explains "No OAuth needed — paste a credential. Works on
+  private/internal instances (outbound HTTPS only)."
+
+### F3. Payload + types
+- Extend `webhookDeliveryPayload.ts`: `format`, slack fields, `slack_bot_token`
+  sentinel-preserve (mirror header secret), glob/kind arrays, validation.
+- Node regression test: slack-mode payload (token sentinel passthrough, channel
+  required, webhook-vs-token mode selection, glob nulls).
+
+## Docs
+- `docs/` page or section: "Slack notifications" — both modes, the no-OAuth
+  rationale (cite the works-on-private-instances property), the manifest, the
+  filter knobs, example YAML. Add a screenshot of the card.
+- Update `deltaglider_proxy.example.yaml` `event_delivery` block with a
+  commented `format: slack` example.
+
+## Gate
+- cargo fmt + clippy -D warnings + test --lib + the new integration test.
+- frontend lint + tsc + knip + build + node regression.
+- config schema regenerates (new enum/fields) — verify CI "Config JSON Schema".
+- Local: restart-with-prod-backup, configure Slack webhook against a test
+  hooks.slack.com URL (or a request-bin), PUT an object, confirm a formatted
+  message is delivered + filtered keys are skipped.

--- a/docs/product/reference/event-outbox.md
+++ b/docs/product/reference/event-outbox.md
@@ -101,6 +101,63 @@ Each POST body is JSON:
 }
 ```
 
+## Slack notifications
+
+Set `event_delivery.format: slack` to deliver Slack messages instead of the raw
+`{schema,event}` envelope. **No OAuth is required** — you paste a credential, so
+this works even when the proxy runs at a private/internal address (delivery is
+outbound HTTPS only). This mirrors how Grafana, self-hosted Sentry, and GitLab CE
+do Slack notifications.
+
+Two modes — pick one:
+
+**Incoming Webhook (simplest, single channel).** In Slack: create an app → enable
+*Incoming Webhooks* → pick a channel → copy the `https://hooks.slack.com/services/…`
+URL into `webhook_url`.
+
+```yaml
+event_delivery:
+  enabled: true
+  format: slack
+  webhook_url: "https://hooks.slack.com/services/T000/B000/XXXX"
+  slack_username: "DeltaGlider"      # optional cosmetic override
+  slack_icon_emoji: ":package:"      # optional
+```
+
+**Bot token (multi-channel + @mentions).** In Slack: create an app → add the
+`chat:write` and `chat:write.public` scopes → install to the workspace → copy the
+`xoxb-…` Bot User OAuth Token. Set it with a target channel (no webhook URL):
+
+```yaml
+event_delivery:
+  enabled: true
+  format: slack
+  slack_bot_token: "xoxb-…"          # secret: masked on export, preserved untouched
+  slack_channel: "C0123456"          # channel id or #name (required in this mode)
+```
+
+The bot token is treated like any other secret: it is masked to `__redacted__` on
+export and in the admin GUI, and an unchanged round-trip preserves the real token.
+The Slack Web API returns HTTP 200 even on failure, so delivery checks the JSON
+`ok` field and retries on `{"ok": false}` (e.g. `channel_not_found`).
+
+**What gets posted.** By default only `ObjectCreated` notifies. Widen or scope it:
+
+```yaml
+  slack_notify_kinds: ["ObjectCreated", "ObjectDeleted"]
+  slack_include_globs: ["builds/**"]   # empty = all user objects
+  slack_exclude_globs: ["**/*.tmp"]    # exclude wins over include
+```
+
+Directory markers and DeltaGlider internals (`reference.bin`, `*.delta`,
+`.deltaglider/*`) are never posted. Each message is Block Kit (header + object
+section + context line with size / storage strategy / timestamp) plus a plain
+`text` fallback for notifications and screen readers.
+
+All of this is editable from the admin GUI at **Configuration → Advanced →
+Webhook delivery** (toggle the format to *Slack*) — including a live preview of
+the message that will land in the channel.
+
 ## Admin API
 
 All routes are session-gated.

--- a/docs/product/reference/event-outbox.md
+++ b/docs/product/reference/event-outbox.md
@@ -154,6 +154,26 @@ Directory markers and DeltaGlider internals (`reference.bin`, `*.delta`,
 section + context line with size / storage strategy / timestamp) plus a plain
 `text` fallback for notifications and screen readers.
 
+**Per-bucket / per-prefix channel routing** (bot-token mode only — Incoming
+Webhook URLs are each bound to one channel by Slack). Set `slack_routes` to send
+different buckets or prefixes to different channels; an eligible event posts to
+**every** route it matches (so one object can hit several channels). `slack_channel`
+becomes the fallback for events that match no route.
+
+```yaml
+  slack_routes:
+    - name: "Releases → #ci"
+      bucket: "releases"
+      prefix_globs: ["builds/**"]   # empty = any key in the bucket
+      channel: "C_CI"
+    - name: "Audit → #security"
+      bucket: "audit"               # no prefix_globs = the whole bucket
+      channel: "C_SECURITY"
+```
+
+The top-level `slack_notify_kinds` + `slack_include/exclude_globs` are a global
+pre-filter (what's eligible at all); routes then decide which channels.
+
 All of this is editable from the admin GUI at **Configuration → Advanced →
 Webhook delivery** (toggle the format to *Slack*) — including a live preview of
 the message that will land in the channel.

--- a/src/api/admin/backup.rs
+++ b/src/api/admin/backup.rs
@@ -390,6 +390,21 @@ struct BackupSecrets {
     /// secrets without replacing users / groups).
     #[serde(default, skip_serializing_if = "std::collections::BTreeMap::is_empty")]
     oauth_client_secrets: std::collections::BTreeMap<String, String>,
+    /// Event-delivery secrets (`advanced.event_delivery.*`): the Slack bot token
+    /// and webhook header values. These are masked in the backup's `config.yaml`
+    /// (redact_all_secrets), so without capturing them here a cross-instance /
+    /// DR restore — where the running instance has no token to preserve from —
+    /// would silently lose them.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    event_delivery: Option<SecretsEventDelivery>,
+}
+
+#[derive(Serialize, Deserialize, Default)]
+struct SecretsEventDelivery {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    slack_bot_token: Option<String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    webhook_headers: BTreeMap<String, String>,
 }
 
 #[derive(Serialize, Deserialize, Default)]
@@ -527,6 +542,7 @@ async fn export_zip(
             storage: None,
             storage_backends: Default::default(),
             oauth_client_secrets: Default::default(),
+            event_delivery: None,
         };
         // Access-section bootstrap SigV4 pair.
         if cfg.access_key_id.is_some() || cfg.secret_access_key.is_some() {
@@ -574,6 +590,20 @@ async fn export_zip(
             if let Some(cs) = &p.client_secret {
                 s.oauth_client_secrets.insert(p.name.clone(), cs.clone());
             }
+        }
+        // Event-delivery secrets (Slack bot token + webhook header values) —
+        // masked in config.yaml, so captured here for cross-instance restore.
+        let ed = &cfg.event_delivery;
+        let has_token = ed
+            .slack_bot_token
+            .as_deref()
+            .map(|t| !t.trim().is_empty())
+            .unwrap_or(false);
+        if has_token || !ed.webhook_headers.is_empty() {
+            s.event_delivery = Some(SecretsEventDelivery {
+                slack_bot_token: ed.slack_bot_token.clone(),
+                webhook_headers: ed.webhook_headers.clone(),
+            });
         }
         s
     };
@@ -905,6 +935,21 @@ fn hydrate_config_with_backup_secrets(cfg: &mut Config, secrets: &BackupSecrets)
             if let [idx] = s3_named.as_slice() {
                 hydrate_s3_backend_credentials(&mut cfg.backends[*idx].backend, s);
             }
+        }
+    }
+
+    // Event-delivery secrets: restore the real Slack bot token + webhook header
+    // values over the masked placeholders in config.yaml. Without this, a
+    // cross-instance / DR restore (where the running instance has no token to
+    // preserve from) would lose them.
+    if let Some(ed) = &secrets.event_delivery {
+        if let Some(tok) = &ed.slack_bot_token {
+            cfg.event_delivery.slack_bot_token = Some(tok.clone());
+        }
+        for (k, v) in &ed.webhook_headers {
+            cfg.event_delivery
+                .webhook_headers
+                .insert(k.clone(), v.clone());
         }
     }
 }

--- a/src/api/admin/config/mod.rs
+++ b/src/api/admin/config/mod.rs
@@ -601,6 +601,11 @@ pub(super) fn preserve_event_delivery_secrets(
     for key in drop_keys {
         new.webhook_headers.remove(&key);
     }
+    // Slack bot token: an untouched (sentinel) value preserves the old token; a
+    // sentinel with no old token to restore is meaningless → clear it.
+    if new.slack_bot_token.as_deref() == Some(sentinel) {
+        new.slack_bot_token = old.slack_bot_token.clone();
+    }
 }
 
 /// Preserve credentials on the PRIMARY backend across a config swap.
@@ -1024,6 +1029,53 @@ mod preserve_tests {
         assert_eq!(
             new.webhook_headers.get("X-Env").map(String::as_str),
             Some("prod")
+        );
+    }
+
+    #[test]
+    fn preserve_slack_bot_token() {
+        // untouched sentinel → restore old token
+        let old = EventDeliveryConfig {
+            slack_bot_token: Some("xoxb-real-token".to_string()),
+            ..Default::default()
+        };
+        let mut new = EventDeliveryConfig {
+            slack_bot_token: Some(REDACTED_SENTINEL.to_string()),
+            ..Default::default()
+        };
+        preserve_event_delivery_secrets(&mut new, &old);
+        assert_eq!(new.slack_bot_token.as_deref(), Some("xoxb-real-token"));
+
+        // retyped token → keep it
+        let mut new2 = EventDeliveryConfig {
+            slack_bot_token: Some("xoxb-NEW".to_string()),
+            ..Default::default()
+        };
+        preserve_event_delivery_secrets(&mut new2, &old);
+        assert_eq!(new2.slack_bot_token.as_deref(), Some("xoxb-NEW"));
+
+        // sentinel with no old token → cleared
+        let mut new3 = EventDeliveryConfig {
+            slack_bot_token: Some(REDACTED_SENTINEL.to_string()),
+            ..Default::default()
+        };
+        preserve_event_delivery_secrets(&mut new3, &EventDeliveryConfig::default());
+        assert_eq!(new3.slack_bot_token, None);
+    }
+
+    #[test]
+    fn redact_masks_slack_bot_token() {
+        let cfg = crate::config::Config {
+            event_delivery: EventDeliveryConfig {
+                slack_bot_token: Some("xoxb-secret".to_string()),
+                ..Default::default()
+            },
+            ..crate::config::Config::default()
+        };
+        let redacted = cfg.redact_all_secrets();
+        assert_eq!(
+            redacted.event_delivery.slack_bot_token.as_deref(),
+            Some(REDACTED_SENTINEL)
         );
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -2044,6 +2044,11 @@ impl Config {
         for value in export.event_delivery.webhook_headers.values_mut() {
             *value = REDACTED_SENTINEL.to_string();
         }
+        // Slack bot token is a secret too — mask it (keep Some so the GUI shows a
+        // token IS configured), preserved on an untouched round-trip.
+        if export.event_delivery.slack_bot_token.is_some() {
+            export.event_delivery.slack_bot_token = Some(REDACTED_SENTINEL.to_string());
+        }
         export
     }
 

--- a/src/config_sections.rs
+++ b/src/config_sections.rs
@@ -709,6 +709,39 @@ pub struct EventDeliveryConfig {
         skip_serializing_if = "Vec::is_empty"
     )]
     pub slack_notify_kinds: Vec<String>,
+
+    /// Per-bucket / per-prefix channel routing (bot-token mode only). When
+    /// NON-EMPTY, an eligible event is posted to EVERY route it matches — so
+    /// different buckets/prefixes can fan out to different channels (and one
+    /// object can hit several). When EMPTY, delivery falls back to the single
+    /// `slack_channel` (the default single-destination behavior).
+    ///
+    /// The top-level `slack_notify_kinds` + `slack_include/exclude_globs` are a
+    /// global pre-filter (what's eligible at all); routes then pick channels.
+    /// Incoming Webhook URLs are each bound to one channel by Slack, so routing
+    /// requires a bot token (`chat.postMessage`).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub slack_routes: Vec<SlackRoute>,
+}
+
+/// One bucket/prefix → channel routing rule. See [`EventDeliveryConfig::slack_routes`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct SlackRoute {
+    /// Optional human label for the route (shown in the GUI; ignored by routing).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+
+    /// Match only this bucket. `None`/absent = any bucket.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bucket: Option<String>,
+
+    /// Match only keys matching at least one of these globs. Empty = any key
+    /// (within the bucket constraint).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub prefix_globs: Vec<String>,
+
+    /// Slack channel to post to (id like `C0123` or `#name`). Required.
+    pub channel: String,
 }
 
 /// Event-delivery payload format. See [`EventDeliveryConfig::format`].
@@ -778,6 +811,7 @@ impl Default for EventDeliveryConfig {
             slack_include_globs: Vec::new(),
             slack_exclude_globs: Vec::new(),
             slack_notify_kinds: default_slack_notify_kinds(),
+            slack_routes: Vec::new(),
         }
     }
 }
@@ -1731,17 +1765,38 @@ pub fn validate_event_delivery(cfg: &EventDeliveryConfig) -> Vec<String> {
 
     // Slack-format validation.
     if cfg.format == EventDeliveryFormat::Slack {
-        if cfg.uses_slack_bot_token()
-            && cfg
-                .slack_channel
-                .as_deref()
-                .map(|c| c.trim().is_empty())
-                .unwrap_or(true)
-        {
+        // A bot-token config needs SOME destination: either per-route channels
+        // OR the single slack_channel fallback.
+        let has_single_channel = cfg
+            .slack_channel
+            .as_deref()
+            .map(|c| !c.trim().is_empty())
+            .unwrap_or(false);
+        if cfg.uses_slack_bot_token() && cfg.slack_routes.is_empty() && !has_single_channel {
             warnings.push(
-                "event_delivery: Slack bot-token mode requires slack_channel; messages will fail until set"
+                "event_delivery: Slack bot-token mode needs either slack_channel or slack_routes; messages will fail until one is set"
                     .to_string(),
             );
+        }
+        if !cfg.slack_routes.is_empty() && !cfg.uses_slack_bot_token() {
+            warnings.push(
+                "event_delivery.slack_routes only applies in bot-token mode (Incoming Webhook URLs are bound to one channel); routes will be ignored"
+                    .to_string(),
+            );
+        }
+        for (i, route) in cfg.slack_routes.iter().enumerate() {
+            if route.channel.trim().is_empty() {
+                warnings.push(format!(
+                    "event_delivery.slack_routes[{i}] has an empty channel"
+                ));
+            }
+            for p in &route.prefix_globs {
+                if globset::Glob::new(p).is_err() {
+                    warnings.push(format!(
+                        "event_delivery.slack_routes[{i}].prefix_globs has invalid glob {p:?}"
+                    ));
+                }
+            }
         }
         for (label, patterns) in [
             ("slack_include_globs", &cfg.slack_include_globs),

--- a/src/config_sections.rs
+++ b/src/config_sections.rs
@@ -663,11 +663,83 @@ pub struct EventDeliveryConfig {
     /// Max delivered rows pruned per tick.
     #[serde(default = "default_event_delivery_prune_batch")]
     pub prune_batch: u32,
+
+    /// Payload format. `raw` (default) posts the `{schema,event}` JSON envelope
+    /// to the webhook endpoints. `slack` formats each event as a Slack message
+    /// (Block Kit + text fallback) — delivered either to an Incoming Webhook URL
+    /// (`webhook_url`/`webhook_urls` pointed at `hooks.slack.com`) or, when
+    /// `slack_bot_token` is set, via the Slack Web API `chat.postMessage`.
+    #[serde(default)]
+    pub format: EventDeliveryFormat,
+
+    /// Slack bot token (`xoxb-…`). When set with `format = slack`, delivery uses
+    /// the Slack Web API (posts to `slack_channel`, supports `@`-mentions and any
+    /// channel via `chat:write.public`) instead of an Incoming Webhook URL.
+    /// SECRET — masked on export, preserved on an untouched round-trip.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub slack_bot_token: Option<String>,
+
+    /// Target Slack channel (id like `C0123` or `#name`). Required in bot-token
+    /// mode; ignored for Incoming Webhook URLs (which are bound to one channel).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub slack_channel: Option<String>,
+
+    /// Cosmetic sender name override (Incoming Webhook mode).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub slack_username: Option<String>,
+
+    /// Cosmetic icon emoji override, e.g. `:package:` (Incoming Webhook mode).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub slack_icon_emoji: Option<String>,
+
+    /// Only object keys matching at least one of these globs notify Slack. Empty
+    /// = all user-object keys. Reuses the replication globset engine.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub slack_include_globs: Vec<String>,
+
+    /// Object keys matching any of these globs are NEVER posted to Slack
+    /// (exclude wins over include).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub slack_exclude_globs: Vec<String>,
+
+    /// Which event kinds post to Slack. Default `["ObjectCreated"]`. Add
+    /// `ObjectDeleted`, `ObjectCopied`, etc. to widen.
+    #[serde(
+        default = "default_slack_notify_kinds",
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub slack_notify_kinds: Vec<String>,
+}
+
+/// Event-delivery payload format. See [`EventDeliveryConfig::format`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum EventDeliveryFormat {
+    /// The `{schema,event}` JSON envelope (existing behavior).
+    #[default]
+    Raw,
+    /// A Slack message (Block Kit + text fallback).
+    Slack,
+}
+
+fn default_slack_notify_kinds() -> Vec<String> {
+    vec!["ObjectCreated".to_string()]
 }
 
 impl EventDeliveryConfig {
     pub fn is_active(&self) -> bool {
-        self.enabled && !self.webhook_endpoints().is_empty()
+        self.enabled && (!self.webhook_endpoints().is_empty() || self.uses_slack_bot_token())
+    }
+
+    /// `true` when Slack delivery is configured to use the Web API (bot token)
+    /// rather than an Incoming Webhook URL.
+    pub fn uses_slack_bot_token(&self) -> bool {
+        self.format == EventDeliveryFormat::Slack
+            && self
+                .slack_bot_token
+                .as_deref()
+                .map(|t| !t.trim().is_empty())
+                .unwrap_or(false)
     }
 
     pub fn webhook_endpoints(&self) -> Vec<&str> {
@@ -698,6 +770,14 @@ impl Default for EventDeliveryConfig {
             delivered_retention: default_event_delivery_retention(),
             delivered_max_rows: default_event_delivery_delivered_max_rows(),
             prune_batch: default_event_delivery_prune_batch(),
+            format: EventDeliveryFormat::default(),
+            slack_bot_token: None,
+            slack_channel: None,
+            slack_username: None,
+            slack_icon_emoji: None,
+            slack_include_globs: Vec::new(),
+            slack_exclude_globs: Vec::new(),
+            slack_notify_kinds: default_slack_notify_kinds(),
         }
     }
 }
@@ -1568,9 +1648,9 @@ pub fn validate_lifecycle(cfg: &LifecycleConfig) -> Vec<String> {
 /// the dispatcher still treats invalid/missing webhook config as inactive.
 pub fn validate_event_delivery(cfg: &EventDeliveryConfig) -> Vec<String> {
     let mut warnings = Vec::new();
-    if cfg.enabled && cfg.webhook_endpoints().is_empty() {
+    if cfg.enabled && cfg.webhook_endpoints().is_empty() && !cfg.uses_slack_bot_token() {
         warnings.push(
-            "event_delivery.enabled=true but no webhook endpoint is configured; dispatcher will stay inactive"
+            "event_delivery.enabled=true but no webhook endpoint (or Slack bot token) is configured; dispatcher will stay inactive"
                 .to_string(),
         );
     }
@@ -1648,6 +1728,48 @@ pub fn validate_event_delivery(cfg: &EventDeliveryConfig) -> Vec<String> {
                 .to_string(),
         );
     }
+
+    // Slack-format validation.
+    if cfg.format == EventDeliveryFormat::Slack {
+        if cfg.uses_slack_bot_token()
+            && cfg
+                .slack_channel
+                .as_deref()
+                .map(|c| c.trim().is_empty())
+                .unwrap_or(true)
+        {
+            warnings.push(
+                "event_delivery: Slack bot-token mode requires slack_channel; messages will fail until set"
+                    .to_string(),
+            );
+        }
+        for (label, patterns) in [
+            ("slack_include_globs", &cfg.slack_include_globs),
+            ("slack_exclude_globs", &cfg.slack_exclude_globs),
+        ] {
+            for p in patterns {
+                if globset::Glob::new(p).is_err() {
+                    warnings.push(format!("event_delivery.{label} has invalid glob {p:?}"));
+                }
+            }
+        }
+        const KNOWN_KINDS: [&str; 6] = [
+            "ObjectCreated",
+            "ObjectDeleted",
+            "ObjectCopied",
+            "ReplicationObjectCopied",
+            "LifecycleTransitioned",
+            "LifecycleExpired",
+        ];
+        for k in &cfg.slack_notify_kinds {
+            if !KNOWN_KINDS.contains(&k.as_str()) {
+                warnings.push(format!(
+                    "event_delivery.slack_notify_kinds has unknown kind {k:?}"
+                ));
+            }
+        }
+    }
+
     warnings
 }
 

--- a/src/event_delivery.rs
+++ b/src/event_delivery.rs
@@ -167,35 +167,45 @@ impl HttpWebhookDeliveryClient {
                 .unwrap_or_default()
                 .trim()
                 .to_string();
-            let channel = config
-                .slack_channel
-                .as_deref()
-                .map(str::trim)
-                .filter(|c| !c.is_empty())
-                .ok_or_else(|| "slack bot-token mode requires slack_channel".to_string())?;
-            if let Value::Object(ref mut map) = body {
-                map.insert("channel".to_string(), Value::String(channel.to_string()));
+            // Resolve target channel(s): per-route fan-out, or the single
+            // slack_channel fallback. An event may hit several channels.
+            let channels = crate::slack_format::resolve_channels(event, config);
+            if channels.is_empty() {
+                // No route matched and no fallback channel — for a routed config
+                // this is a legitimate "post nowhere". For a misconfigured single
+                // destination, surface the missing channel.
+                if config.slack_routes.is_empty() {
+                    return Err("slack bot-token mode requires slack_channel".to_string());
+                }
+                return Ok(()); // routed, but this event matched no route
             }
-            let response = self
-                .client
-                .post("https://slack.com/api/chat.postMessage")
-                .timeout(timeout)
-                .bearer_auth(token)
-                .json(&body)
-                .send()
-                .await
-                .map_err(|e| format!("slack chat.postMessage: {e}"))?;
-            if !response.status().is_success() {
-                return Err(format!(
-                    "slack chat.postMessage returned HTTP {}",
-                    response.status()
-                ));
+            for channel in channels {
+                let mut msg = body.clone();
+                if let Value::Object(ref mut map) = msg {
+                    map.insert("channel".to_string(), Value::String(channel.clone()));
+                }
+                let response = self
+                    .client
+                    .post("https://slack.com/api/chat.postMessage")
+                    .timeout(timeout)
+                    .bearer_auth(&token)
+                    .json(&msg)
+                    .send()
+                    .await
+                    .map_err(|e| format!("slack chat.postMessage ({channel}): {e}"))?;
+                if !response.status().is_success() {
+                    return Err(format!(
+                        "slack chat.postMessage ({channel}) returned HTTP {}",
+                        response.status()
+                    ));
+                }
+                let parsed: Value = response
+                    .json()
+                    .await
+                    .map_err(|e| format!("slack response parse ({channel}): {e}"))?;
+                slack_api_result(&parsed).map_err(|e| format!("{e} (channel {channel})"))?;
             }
-            let parsed: Value = response
-                .json()
-                .await
-                .map_err(|e| format!("slack response parse: {e}"))?;
-            return slack_api_result(&parsed);
+            return Ok(());
         }
 
         // Incoming Webhook mode: POST {text, blocks, username?, icon_emoji?} to

--- a/src/event_delivery.rs
+++ b/src/event_delivery.rs
@@ -3,13 +3,31 @@
 //! Background delivery for the durable event outbox.
 //!
 //! The dispatcher is intentionally conservative: it is disabled unless
-//! `advanced.event_delivery.enabled=true` and `webhook_url` is set. Request
-//! handlers never call this module; they only append to `event_outbox`.
+//! `advanced.event_delivery.enabled=true` and a delivery target is set (a
+//! webhook URL, or — in `format = slack` bot-token mode — a Slack bot token).
+//! Request handlers never call this module; they only append to `event_outbox`.
 
 use crate::background::parse_duration_or;
 use crate::config::SharedConfig;
 use crate::config_db::ConfigDb;
-use crate::config_sections::EventDeliveryConfig;
+use crate::config_sections::{EventDeliveryConfig, EventDeliveryFormat};
+use serde_json::Value;
+
+/// Map a Slack Web API JSON response to a delivery result. The API returns HTTP
+/// 200 even on failure; the authoritative status is the `ok` boolean, with the
+/// reason in `error`. Pure so the bot-token path's success/retry decision is
+/// unit-testable without a live Slack.
+fn slack_api_result(body: &Value) -> Result<(), String> {
+    if body.get("ok").and_then(Value::as_bool) == Some(true) {
+        Ok(())
+    } else {
+        let err = body
+            .get("error")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown");
+        Err(format!("slack chat.postMessage error: {err}"))
+    }
+}
 use crate::event_outbox::{
     current_unix_seconds, EventOutboxRecord, STATUS_DELIVERED, STATUS_FAILED, STATUS_IN_PROGRESS,
     STATUS_PENDING,
@@ -64,6 +82,29 @@ impl EventDeliveryClient for HttpWebhookDeliveryClient {
         config: &EventDeliveryConfig,
         event: &EventOutboxRecord,
     ) -> Result<(), String> {
+        let timeout = parse_duration_or(
+            &config.request_timeout,
+            DEFAULT_TIMEOUT,
+            MIN_TIMEOUT,
+            "event_delivery.request_timeout",
+        );
+
+        match config.format {
+            EventDeliveryFormat::Slack => self.deliver_slack(config, event, timeout).await,
+            EventDeliveryFormat::Raw => self.deliver_raw(config, event, timeout).await,
+        }
+    }
+}
+
+impl HttpWebhookDeliveryClient {
+    /// Existing behavior: POST the `{schema,event}` envelope to every webhook
+    /// endpoint with the configured static headers.
+    async fn deliver_raw(
+        &self,
+        config: &EventDeliveryConfig,
+        event: &EventOutboxRecord,
+        timeout: Duration,
+    ) -> Result<(), String> {
         let endpoints = config.webhook_endpoints();
         if endpoints.is_empty() {
             return Err("event delivery enabled without webhook endpoint".to_string());
@@ -72,12 +113,6 @@ impl EventDeliveryClient for HttpWebhookDeliveryClient {
             schema: "deltaglider.event.v1",
             event,
         };
-        let timeout = parse_duration_or(
-            &config.request_timeout,
-            DEFAULT_TIMEOUT,
-            MIN_TIMEOUT,
-            "event_delivery.request_timeout",
-        );
         for endpoint in endpoints {
             let url = Url::parse(endpoint).map_err(|e| format!("invalid webhook endpoint: {e}"))?;
             let mut request = self
@@ -100,6 +135,97 @@ impl EventDeliveryClient for HttpWebhookDeliveryClient {
             if !response.status().is_success() {
                 return Err(format!(
                     "{endpoint}: webhook returned HTTP {}",
+                    response.status()
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    /// Slack delivery: format the event as a Slack message and POST it either to
+    /// the Incoming Webhook URLs or, when a bot token is set, to the Slack Web
+    /// API `chat.postMessage`. Events filtered out by `should_notify` are a
+    /// silent success (consumed, not posted).
+    async fn deliver_slack(
+        &self,
+        config: &EventDeliveryConfig,
+        event: &EventOutboxRecord,
+        timeout: Duration,
+    ) -> Result<(), String> {
+        let (include, exclude) = crate::slack_format::compile_slack_globs(config)?;
+        if !crate::slack_format::should_notify(event, config, &include, &exclude) {
+            return Ok(()); // not a notifying event — consume without posting
+        }
+        let mut body = crate::slack_format::slack_message(event, config);
+
+        if config.uses_slack_bot_token() {
+            // Slack Web API: chat.postMessage. Returns HTTP 200 even on error —
+            // the real status is in the JSON `{ "ok": bool, "error": ... }`.
+            let token = config
+                .slack_bot_token
+                .as_deref()
+                .unwrap_or_default()
+                .trim()
+                .to_string();
+            let channel = config
+                .slack_channel
+                .as_deref()
+                .map(str::trim)
+                .filter(|c| !c.is_empty())
+                .ok_or_else(|| "slack bot-token mode requires slack_channel".to_string())?;
+            if let Value::Object(ref mut map) = body {
+                map.insert("channel".to_string(), Value::String(channel.to_string()));
+            }
+            let response = self
+                .client
+                .post("https://slack.com/api/chat.postMessage")
+                .timeout(timeout)
+                .bearer_auth(token)
+                .json(&body)
+                .send()
+                .await
+                .map_err(|e| format!("slack chat.postMessage: {e}"))?;
+            if !response.status().is_success() {
+                return Err(format!(
+                    "slack chat.postMessage returned HTTP {}",
+                    response.status()
+                ));
+            }
+            let parsed: Value = response
+                .json()
+                .await
+                .map_err(|e| format!("slack response parse: {e}"))?;
+            return slack_api_result(&parsed);
+        }
+
+        // Incoming Webhook mode: POST {text, blocks, username?, icon_emoji?} to
+        // every configured hooks.slack.com URL. 2xx = delivered.
+        let endpoints = config.webhook_endpoints();
+        if endpoints.is_empty() {
+            return Err("slack delivery enabled without a webhook URL or bot token".to_string());
+        }
+        if let Value::Object(ref mut map) = body {
+            if let Some(u) = config.slack_username.as_deref().filter(|s| !s.is_empty()) {
+                map.insert("username".to_string(), Value::String(u.to_string()));
+            }
+            if let Some(i) = config.slack_icon_emoji.as_deref().filter(|s| !s.is_empty()) {
+                map.insert("icon_emoji".to_string(), Value::String(i.to_string()));
+            }
+        }
+        for endpoint in endpoints {
+            let url =
+                Url::parse(endpoint).map_err(|e| format!("invalid slack webhook URL: {e}"))?;
+            let response = self
+                .client
+                .post(url)
+                .timeout(timeout)
+                .json(&body)
+                .send()
+                .await
+                .map_err(|e| format!("{endpoint}: {e}"))?;
+            if !response.status().is_success() {
+                return Err(format!(
+                    "{endpoint}: slack webhook returned HTTP {}",
                     response.status()
                 ));
             }
@@ -342,8 +468,6 @@ mod tests {
         EventDeliveryConfig {
             enabled: true,
             webhook_url: Some("http://example.invalid/hook".to_string()),
-            webhook_urls: Vec::new(),
-            webhook_headers: Default::default(),
             tick_interval: "1s".to_string(),
             batch_size: 10,
             request_timeout: "1s".to_string(),
@@ -354,6 +478,7 @@ mod tests {
             delivered_retention: "1h".to_string(),
             delivered_max_rows: 10_000,
             prune_batch: 100,
+            ..Default::default()
         }
     }
 
@@ -513,6 +638,105 @@ mod tests {
         assert_eq!(row.attempts, 1);
 
         server.abort();
+    }
+
+    #[tokio::test]
+    async fn slack_webhook_delivery_formats_block_kit_and_filters() {
+        // Mock Slack Incoming Webhook: capture the posted body, return 200.
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<Value>();
+        let app = Router::new().route(
+            "/services/T/B/X",
+            post(move |Json(payload): Json<Value>| {
+                let tx = tx.clone();
+                async move {
+                    tx.send(payload).unwrap();
+                    StatusCode::OK
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base = format!("http://{}", listener.local_addr().unwrap());
+        let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+        let db = Arc::new(Mutex::new(ConfigDb::in_memory("test-pass").unwrap()));
+        // One notifying event + one that the kind filter drops.
+        let created = {
+            let db = db.lock().await;
+            let id = db
+                .event_outbox_insert(&NewEvent::new(
+                    EventKind::ObjectCreated,
+                    "builds",
+                    "ror/app.zip",
+                    EventSource::S3Api,
+                    1_700_000_000,
+                    json!({ "content_length": 2048, "storage_type": "delta" }),
+                ))
+                .unwrap();
+            // A delete — NOT in default notify_kinds → must be skipped (delivered, no POST).
+            db.event_outbox_insert(&NewEvent::new(
+                EventKind::ObjectDeleted,
+                "builds",
+                "ror/old.zip",
+                EventSource::S3Api,
+                1_700_000_001,
+                json!({}),
+            ))
+            .unwrap();
+            id
+        };
+
+        let mut config = cfg();
+        config.format = EventDeliveryFormat::Slack;
+        config.webhook_url = Some(format!("{base}/services/T/B/X"));
+        config.webhook_urls = Vec::new();
+
+        let client = HttpWebhookDeliveryClient::default();
+        dispatch_once(&db, &client, &config, "test-worker", 200).await;
+
+        // Exactly ONE Slack POST (the ObjectCreated); the delete was filtered.
+        let body = timeout(Duration::from_secs(2), rx.recv())
+            .await
+            .unwrap()
+            .expect("one slack message");
+        assert!(
+            rx.try_recv().is_err(),
+            "filtered delete must NOT post to slack"
+        );
+
+        // Block Kit shape + text fallback.
+        assert!(body["text"].as_str().unwrap().contains("New object"));
+        assert!(body["text"]
+            .as_str()
+            .unwrap()
+            .contains("builds/ror/app.zip"));
+        let blocks = body["blocks"].as_array().unwrap();
+        assert_eq!(blocks[0]["type"], "header");
+        assert!(blocks[1]["text"]["text"]
+            .as_str()
+            .unwrap()
+            .contains("`ror/app.zip`"));
+
+        // Both rows end delivered (the created posted; the deleted was consumed).
+        let rows = db.lock().await.event_outbox_recent(10).unwrap();
+        for r in rows {
+            assert_eq!(r.status, STATUS_DELIVERED, "row {} not delivered", r.id);
+        }
+        let _ = created;
+        server.abort();
+    }
+
+    #[test]
+    fn slack_web_api_ok_false_is_failure() {
+        // The Slack Web API returns HTTP 200 even on error; the real status is
+        // the JSON `ok` field. `slack_api_result` is the pure decision used by
+        // the bot-token delivery path.
+        assert!(slack_api_result(&json!({ "ok": true })).is_ok());
+        let err =
+            slack_api_result(&json!({ "ok": false, "error": "channel_not_found" })).unwrap_err();
+        assert!(err.contains("channel_not_found"), "got: {err}");
+        // Missing / malformed ok → failure with "unknown".
+        let err2 = slack_api_result(&json!({})).unwrap_err();
+        assert!(err2.contains("unknown"), "got: {err2}");
     }
 
     #[test]

--- a/src/event_delivery.rs
+++ b/src/event_delivery.rs
@@ -11,7 +11,19 @@ use crate::background::parse_duration_or;
 use crate::config::SharedConfig;
 use crate::config_db::ConfigDb;
 use crate::config_sections::{EventDeliveryConfig, EventDeliveryFormat};
+use crate::event_outbox::{
+    current_unix_seconds, EventOutboxRecord, STATUS_DELIVERED, STATUS_FAILED, STATUS_IN_PROGRESS,
+    STATUS_PENDING,
+};
+use async_trait::async_trait;
+use reqwest::header::{HeaderName, HeaderValue};
+use reqwest::Url;
+use serde::Serialize;
 use serde_json::Value;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::Mutex;
+use tracing::{debug, info, warn};
 
 /// Map a Slack Web API JSON response to a delivery result. The API returns HTTP
 /// 200 even on failure; the authoritative status is the `ok` boolean, with the
@@ -28,18 +40,6 @@ fn slack_api_result(body: &Value) -> Result<(), String> {
         Err(format!("slack chat.postMessage error: {err}"))
     }
 }
-use crate::event_outbox::{
-    current_unix_seconds, EventOutboxRecord, STATUS_DELIVERED, STATUS_FAILED, STATUS_IN_PROGRESS,
-    STATUS_PENDING,
-};
-use async_trait::async_trait;
-use reqwest::header::{HeaderName, HeaderValue};
-use reqwest::Url;
-use serde::Serialize;
-use std::sync::Arc;
-use std::time::Duration;
-use tokio::sync::Mutex;
-use tracing::{debug, info, warn};
 
 const DEFAULT_TICK: Duration = Duration::from_secs(10);
 const MIN_TICK: Duration = Duration::from_secs(1);
@@ -179,33 +179,62 @@ impl HttpWebhookDeliveryClient {
                 }
                 return Ok(()); // routed, but this event matched no route
             }
-            for channel in channels {
+            // Post to each resolved channel, collecting per-channel outcomes.
+            //
+            // CRITICAL (at-least-once + fan-out): the outbox tracks ONE status
+            // per event row, not per channel. If we returned Err the moment any
+            // single channel failed, the whole row would re-queue and the next
+            // retry would re-post to the channels that ALREADY succeeded —
+            // duplicate Slack spam (chat.postMessage has no idempotency key).
+            //
+            // So: a PARTIAL success counts as delivered. We only return Err (→
+            // retry) when EVERY channel failed — in which case a retry re-posts
+            // to all, but none had succeeded, so there's no duplication. Channels
+            // that fail while others succeed are logged and dropped (a missed
+            // notification to one bad channel beats duplicating to the good ones).
+            let mut any_ok = false;
+            let mut failures: Vec<String> = Vec::new();
+            for channel in &channels {
                 let mut msg = body.clone();
                 if let Value::Object(ref mut map) = msg {
                     map.insert("channel".to_string(), Value::String(channel.clone()));
                 }
-                let response = self
-                    .client
-                    .post("https://slack.com/api/chat.postMessage")
-                    .timeout(timeout)
-                    .bearer_auth(&token)
-                    .json(&msg)
-                    .send()
-                    .await
-                    .map_err(|e| format!("slack chat.postMessage ({channel}): {e}"))?;
-                if !response.status().is_success() {
-                    return Err(format!(
-                        "slack chat.postMessage ({channel}) returned HTTP {}",
-                        response.status()
-                    ));
+                let result: Result<(), String> = async {
+                    let response = self
+                        .client
+                        .post("https://slack.com/api/chat.postMessage")
+                        .timeout(timeout)
+                        .bearer_auth(&token)
+                        .json(&msg)
+                        .send()
+                        .await
+                        .map_err(|e| format!("{e}"))?;
+                    if !response.status().is_success() {
+                        return Err(format!("HTTP {}", response.status()));
+                    }
+                    let parsed: Value = response.json().await.map_err(|e| format!("parse: {e}"))?;
+                    slack_api_result(&parsed)
                 }
-                let parsed: Value = response
-                    .json()
-                    .await
-                    .map_err(|e| format!("slack response parse ({channel}): {e}"))?;
-                slack_api_result(&parsed).map_err(|e| format!("{e} (channel {channel})"))?;
+                .await;
+                match result {
+                    Ok(()) => any_ok = true,
+                    Err(e) => {
+                        warn!("slack chat.postMessage to {channel} failed: {e}");
+                        failures.push(format!("{channel}: {e}"));
+                    }
+                }
             }
-            return Ok(());
+            // Partial success (≥1 channel OK) or all OK → delivered. Only when
+            // EVERY channel failed do we fail the row for retry (no dup risk —
+            // nothing was delivered yet).
+            if any_ok {
+                return Ok(());
+            }
+            return Err(format!(
+                "slack chat.postMessage failed for all {} channel(s): {}",
+                channels.len(),
+                failures.join("; ")
+            ));
         }
 
         // Incoming Webhook mode: POST {text, blocks, username?, icon_emoji?} to

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ pub mod s3_adapter_s3s;
 pub mod secret;
 pub mod security;
 pub mod session;
+pub mod slack_format;
 pub mod storage;
 pub mod tls;
 pub(crate) mod transfer;

--- a/src/slack_format.rs
+++ b/src/slack_format.rs
@@ -62,6 +62,51 @@ pub fn compile_slack_globs(cfg: &EventDeliveryConfig) -> Result<(GlobSet, GlobSe
     ))
 }
 
+/// Resolve which Slack channel(s) an eligible event posts to (bot-token mode).
+///
+/// - If `slack_routes` is non-empty, return the channel of EVERY route the event
+///   matches (bucket match — `None` = any; AND prefix globs — empty = any),
+///   deduped, order-preserving. An event can hit several channels, or none.
+/// - If `slack_routes` is empty, fall back to the single `slack_channel`
+///   (the default single-destination behavior) when set.
+///
+/// Returns an empty Vec when nothing matches (caller treats it as "delivered,
+/// posted nowhere" — not an error).
+pub fn resolve_channels(event: &EventOutboxRecord, cfg: &EventDeliveryConfig) -> Vec<String> {
+    if cfg.slack_routes.is_empty() {
+        return cfg
+            .slack_channel
+            .as_deref()
+            .map(str::trim)
+            .filter(|c| !c.is_empty())
+            .map(|c| vec![c.to_string()])
+            .unwrap_or_default();
+    }
+    let mut out: Vec<String> = Vec::new();
+    for route in &cfg.slack_routes {
+        // Bucket constraint.
+        if let Some(b) = route.bucket.as_deref() {
+            if !b.trim().is_empty() && b != event.bucket {
+                continue;
+            }
+        }
+        // Prefix-glob constraint (empty = any key).
+        if !route.prefix_globs.is_empty() {
+            let Ok(set) = build_globset(&route.prefix_globs) else {
+                continue; // an invalid route glob never matches (also surfaced as a config warning)
+            };
+            if !set.is_match(&event.key) {
+                continue;
+            }
+        }
+        let ch = route.channel.trim();
+        if !ch.is_empty() && !out.iter().any(|c| c == ch) {
+            out.push(ch.to_string());
+        }
+    }
+    out
+}
+
 /// Emoji + human title for an event kind.
 fn kind_presentation(kind: &str) -> (&'static str, &'static str) {
     match kind {
@@ -337,5 +382,123 @@ mod tests {
             &inc,
             &exc
         ));
+    }
+
+    // ── resolve_channels (per-bucket / per-prefix routing) ──
+    use crate::config_sections::SlackRoute;
+
+    fn route(name: &str, bucket: Option<&str>, globs: &[&str], channel: &str) -> SlackRoute {
+        SlackRoute {
+            name: Some(name.to_string()),
+            bucket: bucket.map(String::from),
+            prefix_globs: globs.iter().map(|s| s.to_string()).collect(),
+            channel: channel.to_string(),
+        }
+    }
+
+    #[test]
+    fn resolve_channels_falls_back_to_single_channel_when_no_routes() {
+        let cfg = EventDeliveryConfig {
+            slack_channel: Some("C_DEFAULT".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(
+            resolve_channels(&rec("ObjectCreated", "b", "k.zip", json!({})), &cfg),
+            vec!["C_DEFAULT".to_string()]
+        );
+        // No channel + no routes → nowhere.
+        let empty = EventDeliveryConfig::default();
+        assert!(
+            resolve_channels(&rec("ObjectCreated", "b", "k.zip", json!({})), &empty).is_empty()
+        );
+    }
+
+    #[test]
+    fn resolve_channels_routes_by_bucket() {
+        let cfg = EventDeliveryConfig {
+            slack_channel: Some("C_IGNORED".to_string()), // ignored once routes exist
+            slack_routes: vec![
+                route("rel", Some("releases"), &[], "C_RELEASES"),
+                route("aud", Some("audit"), &[], "C_SECURITY"),
+            ],
+            ..Default::default()
+        };
+        assert_eq!(
+            resolve_channels(&rec("ObjectCreated", "releases", "x.zip", json!({})), &cfg),
+            vec!["C_RELEASES".to_string()]
+        );
+        assert_eq!(
+            resolve_channels(&rec("ObjectCreated", "audit", "log.json", json!({})), &cfg),
+            vec!["C_SECURITY".to_string()]
+        );
+        // A bucket no route covers → nowhere (routed config, no fallback).
+        assert!(
+            resolve_channels(&rec("ObjectCreated", "scratch", "x", json!({})), &cfg).is_empty()
+        );
+    }
+
+    #[test]
+    fn resolve_channels_fans_out_to_multiple_matches() {
+        let cfg = EventDeliveryConfig {
+            slack_routes: vec![
+                route("all-releases", Some("releases"), &[], "C_TEAM"),
+                route("builds-only", Some("releases"), &["builds/**"], "C_CI"),
+            ],
+            ..Default::default()
+        };
+        // A builds key matches BOTH routes → fans out to both channels.
+        assert_eq!(
+            resolve_channels(
+                &rec("ObjectCreated", "releases", "builds/app.zip", json!({})),
+                &cfg
+            ),
+            vec!["C_TEAM".to_string(), "C_CI".to_string()]
+        );
+        // A non-builds key matches only the first.
+        assert_eq!(
+            resolve_channels(
+                &rec("ObjectCreated", "releases", "docs/readme.md", json!({})),
+                &cfg
+            ),
+            vec!["C_TEAM".to_string()]
+        );
+    }
+
+    #[test]
+    fn resolve_channels_prefix_glob_and_any_bucket() {
+        let cfg = EventDeliveryConfig {
+            slack_routes: vec![
+                // any bucket, only *.zip → one channel
+                route("zips", None, &["**/*.zip"], "C_ARTIFACTS"),
+            ],
+            ..Default::default()
+        };
+        assert_eq!(
+            resolve_channels(
+                &rec("ObjectCreated", "anybucket", "deep/x.zip", json!({})),
+                &cfg
+            ),
+            vec!["C_ARTIFACTS".to_string()]
+        );
+        assert!(resolve_channels(
+            &rec("ObjectCreated", "anybucket", "deep/x.txt", json!({})),
+            &cfg
+        )
+        .is_empty());
+    }
+
+    #[test]
+    fn resolve_channels_dedupes_same_channel() {
+        let cfg = EventDeliveryConfig {
+            slack_routes: vec![
+                route("a", Some("b"), &[], "C_SAME"),
+                route("b", Some("b"), &["**"], "C_SAME"), // both match → dedupe
+            ],
+            ..Default::default()
+        };
+        assert_eq!(
+            resolve_channels(&rec("ObjectCreated", "b", "x", json!({})), &cfg),
+            vec!["C_SAME".to_string()]
+        );
     }
 }

--- a/src/slack_format.rs
+++ b/src/slack_format.rs
@@ -1,0 +1,341 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+//! Slack message formatting + notification filtering for event delivery.
+//!
+//! When `event_delivery.format = slack`, each outbox event is rendered as a
+//! Slack message (Block Kit blocks + a `text` fallback for notifications and
+//! screen readers) instead of the raw `{schema,event}` JSON envelope. Delivery
+//! goes to either an Incoming Webhook URL or the Slack Web API
+//! (`chat.postMessage`) — see `event_delivery.rs`.
+//!
+//! This module is PURE: `slack_message` builds a JSON value from an event +
+//! config, and `should_notify` decides whether an event posts at all. Both are
+//! unit-tested without any HTTP.
+
+use globset::{Glob, GlobSet, GlobSetBuilder};
+use serde_json::{json, Value};
+
+use crate::config_sections::EventDeliveryConfig;
+use crate::event_outbox::EventOutboxRecord;
+use crate::replication::event_consumer::is_user_object_key;
+
+/// Build a globset from patterns; an empty pattern list yields an empty set
+/// (matches nothing — callers treat "empty include" as "match all").
+fn build_globset(patterns: &[String]) -> Result<GlobSet, String> {
+    let mut b = GlobSetBuilder::new();
+    for p in patterns {
+        b.add(Glob::new(p).map_err(|e| format!("invalid slack glob {p:?}: {e}"))?);
+    }
+    b.build()
+        .map_err(|e| format!("slack globset build failed: {e}"))
+}
+
+/// Whether `event` should post to Slack under `cfg`'s filters: the kind must be
+/// in `slack_notify_kinds`, the key must be a real user object, and it must pass
+/// the include/exclude globs (empty include = all; exclude always wins).
+///
+/// `include`/`exclude` are passed pre-compiled so a drain can build them once.
+pub fn should_notify(
+    event: &EventOutboxRecord,
+    cfg: &EventDeliveryConfig,
+    include: &GlobSet,
+    exclude: &GlobSet,
+) -> bool {
+    if !cfg.slack_notify_kinds.iter().any(|k| k == &event.kind) {
+        return false;
+    }
+    if !is_user_object_key(&event.key) {
+        return false;
+    }
+    if exclude.is_match(&event.key) {
+        return false;
+    }
+    cfg.slack_include_globs.is_empty() || include.is_match(&event.key)
+}
+
+/// Compile the (include, exclude) globsets for a Slack config. Done once per
+/// delivery batch by the caller.
+pub fn compile_slack_globs(cfg: &EventDeliveryConfig) -> Result<(GlobSet, GlobSet), String> {
+    Ok((
+        build_globset(&cfg.slack_include_globs)?,
+        build_globset(&cfg.slack_exclude_globs)?,
+    ))
+}
+
+/// Emoji + human title for an event kind.
+fn kind_presentation(kind: &str) -> (&'static str, &'static str) {
+    match kind {
+        "ObjectCreated" => ("📦", "New object"),
+        "ObjectCopied" | "ReplicationObjectCopied" => ("📑", "Object copied"),
+        "ObjectDeleted" => ("🗑️", "Object deleted"),
+        "LifecycleTransitioned" => ("➿", "Lifecycle transition"),
+        "LifecycleExpired" => ("⌛", "Lifecycle expiry"),
+        _ => ("🔔", "Object event"),
+    }
+}
+
+/// Humanize a byte count for the message (e.g. 1536 → "1.5 KB").
+fn human_size(bytes: i64) -> String {
+    if bytes < 0 {
+        return "unknown size".to_string();
+    }
+    const UNITS: [&str; 5] = ["B", "KB", "MB", "GB", "TB"];
+    let mut size = bytes as f64;
+    let mut unit = 0;
+    while size >= 1024.0 && unit < UNITS.len() - 1 {
+        size /= 1024.0;
+        unit += 1;
+    }
+    if unit == 0 {
+        format!("{bytes} B")
+    } else {
+        format!("{size:.1} {}", UNITS[unit])
+    }
+}
+
+/// Slack escapes `&`, `<`, `>` in message text (mrkdwn).
+fn escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
+/// Build the Slack message body (without `channel`/`username` — the delivery
+/// layer adds those). Returns `{ text, blocks }`:
+/// - `text` is the screen-reader / notification fallback.
+/// - `blocks` is the rich Block Kit rendering (header + section + context).
+pub fn slack_message(event: &EventOutboxRecord, _cfg: &EventDeliveryConfig) -> Value {
+    let (emoji, title) = kind_presentation(&event.kind);
+    let bucket = escape(&event.bucket);
+    let key = escape(&event.key);
+
+    // Pull optional details from the event payload (ObjectCreated carries these).
+    let size = event
+        .payload
+        .get("content_length")
+        .and_then(|v| v.as_i64())
+        .map(human_size);
+    let storage = event
+        .payload
+        .get("storage_type")
+        .and_then(|v| v.as_str())
+        .map(escape);
+    let etag = event
+        .payload
+        .get("etag")
+        .and_then(|v| v.as_str())
+        .map(|e| escape(e.trim_matches('"')));
+
+    // Plain-text fallback (accessibility / notification preview).
+    let mut text = format!("{emoji} {title}: {bucket}/{key}");
+    if let Some(s) = &size {
+        text.push_str(&format!(" ({s})"));
+    }
+
+    // Context line: storage strategy · etag · timestamp.
+    let mut context_bits: Vec<String> = Vec::new();
+    if let Some(s) = &storage {
+        context_bits.push(format!("storage: {s}"));
+    }
+    if let Some(e) = &etag {
+        let short = if e.len() > 12 { &e[..12] } else { e.as_str() };
+        context_bits.push(format!("etag: {short}"));
+    }
+    context_bits.push(format!("at: {}", iso8601(event.occurred_at)));
+
+    let mut section_text = format!("*{bucket}*/`{key}`");
+    if let Some(s) = &size {
+        section_text.push_str(&format!("\nSize: *{s}*"));
+    }
+
+    json!({
+        "text": text,
+        "blocks": [
+            {
+                "type": "header",
+                "text": { "type": "plain_text", "text": format!("{emoji} {title}"), "emoji": true }
+            },
+            {
+                "type": "section",
+                "text": { "type": "mrkdwn", "text": section_text }
+            },
+            {
+                "type": "context",
+                "elements": [
+                    { "type": "mrkdwn", "text": context_bits.join("  ·  ") }
+                ]
+            }
+        ]
+    })
+}
+
+/// Format a unix timestamp as ISO-8601 UTC (no chrono dependency churn — we use
+/// the same approach as the audit log).
+fn iso8601(unix_secs: i64) -> String {
+    use chrono::{TimeZone, Utc};
+    Utc.timestamp_opt(unix_secs, 0)
+        .single()
+        .map(|dt| dt.format("%Y-%m-%dT%H:%M:%SZ").to_string())
+        .unwrap_or_else(|| unix_secs.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rec(kind: &str, bucket: &str, key: &str, payload: Value) -> EventOutboxRecord {
+        EventOutboxRecord {
+            id: 1,
+            kind: kind.to_string(),
+            bucket: bucket.to_string(),
+            key: key.to_string(),
+            source: "s3_api".to_string(),
+            occurred_at: 1_700_000_000,
+            payload,
+            status: "pending".to_string(),
+            attempts: 0,
+            next_attempt_at: None,
+            claimed_by: None,
+            claimed_at: None,
+            delivered_at: None,
+            last_error: None,
+            created_at: 0,
+        }
+    }
+
+    fn cfg_with(kinds: &[&str], include: &[&str], exclude: &[&str]) -> EventDeliveryConfig {
+        EventDeliveryConfig {
+            slack_notify_kinds: kinds.iter().map(|s| s.to_string()).collect(),
+            slack_include_globs: include.iter().map(|s| s.to_string()).collect(),
+            slack_exclude_globs: exclude.iter().map(|s| s.to_string()).collect(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn human_size_units() {
+        assert_eq!(human_size(0), "0 B");
+        assert_eq!(human_size(512), "512 B");
+        assert_eq!(human_size(1536), "1.5 KB");
+        assert_eq!(human_size(5 * 1024 * 1024), "5.0 MB");
+        assert_eq!(human_size(-1), "unknown size");
+    }
+
+    #[test]
+    fn message_has_text_fallback_and_blocks() {
+        let e = rec(
+            "ObjectCreated",
+            "builds",
+            "ror/1.0/app.zip",
+            json!({ "content_length": 1536, "storage_type": "delta", "etag": "\"abc123def456gh\"" }),
+        );
+        let m = slack_message(&e, &EventDeliveryConfig::default());
+        let text = m["text"].as_str().unwrap();
+        assert!(text.contains("New object"), "text fallback: {text}");
+        assert!(text.contains("builds/ror/1.0/app.zip"));
+        assert!(text.contains("1.5 KB"));
+        let blocks = m["blocks"].as_array().unwrap();
+        assert_eq!(blocks[0]["type"], "header");
+        assert_eq!(blocks[1]["type"], "section");
+        assert_eq!(blocks[2]["type"], "context");
+        // section carries bucket/key + size; context carries storage + etag (truncated) + ts.
+        let section = blocks[1]["text"]["text"].as_str().unwrap();
+        assert!(section.contains("*builds*"));
+        assert!(section.contains("`ror/1.0/app.zip`"));
+        let ctx = blocks[2]["elements"][0]["text"].as_str().unwrap();
+        assert!(ctx.contains("storage: delta"));
+        assert!(ctx.contains("etag: abc123def456")); // 12-char truncation, quotes stripped
+        assert!(ctx.contains("2023-11-14")); // iso8601 of 1_700_000_000
+    }
+
+    #[test]
+    fn message_escapes_mrkdwn_special_chars() {
+        let e = rec("ObjectCreated", "b<ad", "a&b>c", json!({}));
+        let m = slack_message(&e, &EventDeliveryConfig::default());
+        let text = m["text"].as_str().unwrap();
+        assert!(text.contains("b&lt;ad"));
+        assert!(text.contains("a&amp;b&gt;c"));
+    }
+
+    #[test]
+    fn should_notify_kind_filter() {
+        let cfg = cfg_with(&["ObjectCreated"], &[], &[]);
+        let (inc, exc) = compile_slack_globs(&cfg).unwrap();
+        assert!(should_notify(
+            &rec("ObjectCreated", "b", "k.zip", json!({})),
+            &cfg,
+            &inc,
+            &exc
+        ));
+        // ObjectDeleted not in notify_kinds → skip.
+        assert!(!should_notify(
+            &rec("ObjectDeleted", "b", "k.zip", json!({})),
+            &cfg,
+            &inc,
+            &exc
+        ));
+    }
+
+    #[test]
+    fn should_notify_skips_internal_keys() {
+        let cfg = cfg_with(&["ObjectCreated"], &[], &[]);
+        let (inc, exc) = compile_slack_globs(&cfg).unwrap();
+        assert!(!should_notify(
+            &rec("ObjectCreated", "b", "ror/.dg/reference.bin", json!({})),
+            &cfg,
+            &inc,
+            &exc
+        ));
+        assert!(!should_notify(
+            &rec("ObjectCreated", "b", "dir/", json!({})),
+            &cfg,
+            &inc,
+            &exc
+        ));
+        assert!(should_notify(
+            &rec("ObjectCreated", "b", "real.zip", json!({})),
+            &cfg,
+            &inc,
+            &exc
+        ));
+    }
+
+    #[test]
+    fn should_notify_include_exclude_globs() {
+        // include only builds/**, exclude **/*.tmp
+        let cfg = cfg_with(&["ObjectCreated"], &["builds/**"], &["**/*.tmp"]);
+        let (inc, exc) = compile_slack_globs(&cfg).unwrap();
+        assert!(should_notify(
+            &rec("ObjectCreated", "b", "builds/app.zip", json!({})),
+            &cfg,
+            &inc,
+            &exc
+        ));
+        // outside include → skip
+        assert!(!should_notify(
+            &rec("ObjectCreated", "b", "logs/x.txt", json!({})),
+            &cfg,
+            &inc,
+            &exc
+        ));
+        // matches include but also exclude → exclude wins
+        assert!(!should_notify(
+            &rec("ObjectCreated", "b", "builds/scratch.tmp", json!({})),
+            &cfg,
+            &inc,
+            &exc
+        ));
+    }
+
+    #[test]
+    fn empty_include_matches_all_user_objects() {
+        let cfg = cfg_with(&["ObjectCreated"], &[], &[]);
+        let (inc, exc) = compile_slack_globs(&cfg).unwrap();
+        assert!(should_notify(
+            &rec("ObjectCreated", "b", "anything/deep/x.bin", json!({})),
+            &cfg,
+            &inc,
+            &exc
+        ));
+    }
+}


### PR DESCRIPTION
## Slack notifications connector (no OAuth)

Adds Slack as a delivery **format** on the existing `event_delivery` pipeline — "new file → post to a Slack channel" — reusing the durable outbox, retries, and the secret-masking GUI.

### Why no OAuth
Follows the Grafana / self-hosted Sentry / GitLab CE model: **paste a credential**, not an OAuth "Add to Slack" flow. The key property for a self-hosted proxy: it **works at private/internal addresses** (delivery is outbound HTTPS only — no public callback the way OAuth/slash-commands require).

### Two modes (pick one)
- **Incoming Webhook** — paste a `hooks.slack.com/…` URL (single channel, zero setup).
- **Bot token** — paste an `xoxb-` token + channel (multi-channel + `@mentions` via `chat:write.public`). Handles the Slack quirk where the Web API returns HTTP 200 with `{"ok": false}` → parsed and retried.

### Secret-safe
`slack_bot_token` is masked to `__redacted__` on every export and preserved-on-untouched on both the section-PUT and full-document export→apply paths (same hardening as webhook header secrets).

### GUI
Configuration → Advanced → Webhook delivery → toggle format to **Slack**: a neat card with a no-OAuth callout, per-mode setup guides, masked token field, notify-kind + include/exclude prefix filters, and a **live preview** of the message that lands in the channel.

### Volume control
`is_user_object_key` (skips dir markers + DG internals) + `slack_notify_kinds` (default `ObjectCreated`) + include/exclude globs so a busy bucket doesn't flood the channel.

### Tests
- 992 lib tests (incl. `slack_format` formatter/filter + `slack_api_result` ok:false + delivery integration with a mock Slack endpoint + token redact/preserve); clippy `-D warnings` clean.
- Frontend lint/tsc/knip/build + extended Node regression test green.
- Verified live: config round-trip, token masked, no leak, preserve-on-untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
